### PR TITLE
Swapping `neutral` root variables

### DIFF
--- a/public/browse.css
+++ b/public/browse.css
@@ -9,8 +9,8 @@ body {
   --search-blue-500: #0c5292;
   --search-blue-600: var(--color-blue-400);
 
-  --search-neutral-100: #f2f2f2;
-  --search-neutral-200: #fafafa;
+  --search-neutral-100: #fafafa;
+  --search-neutral-200: #f2f2f2;
   --search-neutral-300: #e5e5e5;
   --search-neutral-400: #ccc;
   --search-neutral-500: #6e6e6e;
@@ -60,7 +60,7 @@ h1 {
 }
 
 .search-box select {
-  background: var(--search-neutral-200);
+  background: var(--search-neutral-100);
 
   padding-right: var(--space-xx-large);
 }
@@ -186,8 +186,8 @@ a {
 
 .datastores-nav {
   padding-top: var(--space-small);
-  border-bottom: solid 2px var(--search-neutral-100);
-  background: var(--search-neutral-200)
+  border-bottom: solid 2px var(--search-neutral-200);
+  background: var(--search-neutral-100)
 }
 
 .menu-nav {


### PR DESCRIPTION
# Overview
While working on the [Figma components](https://www.figma.com/file/ymqm7jMhh1xFIONkNZZrcB/?node-id=228%3A9142), I realized the order from lightest to darkest was out of place between `var(--search-neutral-100)` and `var(--search-neutral-200)`.

![Screen Shot 2021-11-18 at 12 56 55 PM](https://user-images.githubusercontent.com/27687379/142471139-a0846594-712b-4d86-832c-212c406fbf6d.png)
_Left: Previous order. Right: New order._

This pull request updates that order.

## Anything else?
I was unsuccessful in trying to pull up [http://localhost:4567/](http://localhost:4567/) to test it, so I had to make tests within the browser to see if my changes worked.

## Testing
- Make sure the PR is consistent in these browsers:
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge
- Run accessibility tests:
  - [ ] WAVE
  - [ ] ARC Toolkit
  - [ ] axe DevTools
