### PR TITLE
Updating pagination layout and styles

### DIFF
--- a/public/browse.css
+++ b/public/browse.css
@@ -162,25 +162,25 @@ a {
 /*
   Pagination
 */
-ul.pagination {
+nav.pagination ul {
   display: flex;
   line-height: 1;
   list-style: none;
   padding-left: 0;
 }
 
-ul.pagination li + li {
+nav.pagination ul li + li {
   border-left: 1px solid var(--color-neutral-400);
   margin-left: var(--space-small);
   padding-left: var(--space-small);
 }
 
-ul.pagination li a {
+nav.pagination a {
   align-items: center;
   display: flex;
 }
 
-ul.pagination li m-icon svg {
+nav.pagination m-icon svg {
   position: relative;
   top: var(--space-xxx-small);
   width: 24px;

--- a/public/browse.css
+++ b/public/browse.css
@@ -171,8 +171,8 @@ ul.pagination {
 
 ul.pagination li + li {
   border-left: 1px solid var(--color-neutral-400);
-  margin-left: var(--space-medium);
-  padding-left: var(--space-medium);
+  margin-left: var(--space-small);
+  padding-left: var(--space-small);
 }
 
 ul.pagination li a {

--- a/public/browse.css
+++ b/public/browse.css
@@ -48,6 +48,13 @@ h1 {
 }
 
 /*
+  Images
+*/
+m-icon svg {
+  height: auto;
+}
+
+/*
   Reset input and select styles.
 */
 .search-box select,
@@ -150,6 +157,35 @@ h1 {
 
 a {
   color: var(--search-blue-400);
+}
+
+/*
+  Pagination
+*/
+ul.pagination {
+  display: flex;
+  line-height: 1;
+  list-style: none;
+  padding-left: 0;
+}
+
+ul.pagination li + li {
+  border-left: 1px solid var(--color-neutral-400);
+  margin-left: var(--space-medium);
+  padding-left: var(--space-medium);
+}
+
+ul.pagination li a {
+  align-items: center;
+  display: flex;
+}
+
+ul.pagination li a span {
+  margin-bottom: var(--space-xx-small);
+}
+
+ul.pagination li m-icon svg {
+  width: 24px;
 }
 
 /*

--- a/public/browse.css
+++ b/public/browse.css
@@ -180,11 +180,9 @@ ul.pagination li a {
   display: flex;
 }
 
-ul.pagination li a span {
-  margin-bottom: var(--space-xx-small);
-}
-
 ul.pagination li m-icon svg {
+  position: relative;
+  top: var(--space-xxx-small);
   width: 24px;
 }
 

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -43,9 +43,15 @@ html lang="en"
     main class="viewport-container" style="margin-top: var(--space-x-large);"
       h1 style="margin-top: 0;" Browse `#{list.original_reference}` in call numbers
       
-      p style="margin-bottom: var(--space-medium);"
-        a href=list.previous_url style="margin-right: var(--space-medium);" Previous page
-        a href=list.next_url Next page
+      ul class="pagination"
+        li 
+          a href=list.previous_url
+            m-icon name="keyboard-arrow-left"
+            span Previous page
+        li 
+          a href=list.next_url
+            span Next page
+            m-icon name="keyboard-arrow-right"
 
       table class="table browse-table" cellspacing="0"
         thead
@@ -71,9 +77,15 @@ html lang="en"
                   - result.subtitles.each do |subtitle|
                     p = subtitle
 
-      p style="margin-bottom: var(--space-medium);"
-        a href=list.previous_url style="margin-right: var(--space-medium);" Previous page
-        a href=list.next_url Next page
+      ul class="pagination"
+        li 
+          a href=list.previous_url
+            m-icon name="keyboard-arrow-left"
+            span Previous page
+        li 
+          a href=list.next_url
+            span Next page
+            m-icon name="keyboard-arrow-right"
 
     footer class="page-footer" style="margin-top: var(--space-xxx-large)"
       div class="viewport-container"

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -43,15 +43,16 @@ html lang="en"
     main class="viewport-container" style="margin-top: var(--space-x-large);"
       h1 style="margin-top: 0;" Browse `#{list.original_reference}` in call numbers
       
-      ul class="pagination"
-        li 
-          a href=list.previous_url
-            m-icon name="keyboard-arrow-left"
-            span Previous page
-        li 
-          a href=list.next_url
-            span Next page
-            m-icon name="keyboard-arrow-right"
+      nav class="pagination" aria-label="Top pagination"
+        ul
+          li
+            a href=list.previous_url
+              m-icon name="keyboard-arrow-left"
+              | Previous page
+          li
+            a href=list.next_url
+              | Next page
+              m-icon name="keyboard-arrow-right"
 
       table class="table browse-table" cellspacing="0"
         thead
@@ -77,15 +78,16 @@ html lang="en"
                   - result.subtitles.each do |subtitle|
                     p = subtitle
 
-      ul class="pagination"
-        li 
-          a href=list.previous_url
-            m-icon name="keyboard-arrow-left"
-            span Previous page
-        li 
-          a href=list.next_url
-            span Next page
-            m-icon name="keyboard-arrow-right"
+      nav class="pagination" aria-label="Bottom pagination"
+        ul
+          li
+            a href=list.previous_url
+              m-icon name="keyboard-arrow-left"
+              | Previous page
+          li
+            a href=list.next_url
+              | Next page
+              m-icon name="keyboard-arrow-right"
 
     footer class="page-footer" style="margin-top: var(--space-xxx-large)"
       div class="viewport-container"


### PR DESCRIPTION
# Overview
This pull request updates the pagination to look more like the [Figma design](https://www.figma.com/file/ymqm7jMhh1xFIONkNZZrcB/?node-id=0%3A9201).

![Screen Shot 2021-11-19 at 9 00 45 AM](https://user-images.githubusercontent.com/27687379/142634833-fef2371c-7d8f-4016-8b02-15c57303a415.png)

The pagination has been converted to an unordered list, and has been given a `.pagination` class to cover the styles. `m-icon` components have been added to create the left/right arrows.

## Testing
- Make sure the PR is consistent in these browsers:
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge
- Run accessibility tests:
  - [ ] WAVE
  - [ ] ARC Toolkit
  - [ ] axe DevTools
