### PR TITLE
Adding skip links section and styles

### DIFF
--- a/public/browse.css
+++ b/public/browse.css
@@ -1,3 +1,6 @@
+html {
+  scroll-behavior: smooth;
+}
 body {
   /*
     Search Product original colors.
@@ -36,9 +39,43 @@ body {
   grid-template-rows: auto auto auto auto 1fr auto;
 }
 
+/*
+  Skip links
+*/
+.site-skip-links {
+  background: var(--color-blue-400);
+}
+
+.site-skip-links:not(:focus-within) {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.site-skip-links a {
+  color: white;
+  padding: var(--space-x-small);
+}
+.site-skip-links ul {
+    margin: var(--space-medium) 0;
+    text-align: center;
+}
+
+.site-skip-links ul li + li {
+  margin-top: var(--space-medium);
+}
+
+
 h1 {
   font-weight: 400;
   font-size: 2rem;
+}
+
+h1#maincontent {
+  margin-top: var(--space-xx-large);
 }
 
 .search-box {

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -100,4 +100,3 @@ html lang="en"
     
     m-chat
       div id="chat" tabindex="-1"
-

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -100,4 +100,4 @@ html lang="en"
     
     m-chat
       div id="chat" tabindex="-1"
-    
+

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -13,7 +13,16 @@ html lang="en"
     link href="/browse.css" rel="stylesheet"
     script type="module" src="https://unpkg.com/@umich-lib/web@1/dist/umich-lib/umich-lib.esm.js">
   body
+    section aria-label="Skip links" class="site-skip-links"
+      div class="viewport-container"
+        ul
+          li
+            a href="#maincontent" Skip to main content
+          li
+            a href="#chat" Skip to Ask a Librarian chat
+
     m-universal-header
+    
     m-website-header name="Search" to="https://search.lib.umich.edu/" variant="dark"
 
     form class="search-box" method="get"
@@ -40,8 +49,8 @@ html lang="en"
               - else
                 a href=datastore[:href] = datastore[:label]
 
-    main class="viewport-container" style="margin-top: var(--space-x-large);"
-      h1 style="margin-top: 0;" Browse `#{list.original_reference}` in call numbers
+    main class="viewport-container"
+      h1 id="maincontent" tabindex="-1" Browse `#{list.original_reference}` in call numbers
       
       p style="margin-bottom: var(--space-medium);"
         a href=list.previous_url style="margin-right: var(--space-medium);" Previous page
@@ -90,4 +99,5 @@ html lang="en"
         p style="color: white; text-align: center; margin-bottom: 0;" ©2018 Regents of the University of Michigan. For details and exceptions, see the Copyright Policy.
     
     m-chat
+      div id="chat" tabindex="-1"
     


### PR DESCRIPTION
# Overview
In an effort to increase accessibility, a "Skip links" section has been added. It contains two links:
* Skip to main content (takes you to the `h1`)
* Skip to Ask a Librarian chat (takes you to `m-chat`)

## Testing
- Make sure the PR is consistent in these browsers:
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge
- Run accessibility tests:
  - [ ] WAVE
  - [ ] ARC Toolkit
  - [ ] axe DevTools
- Tab through section and click on the links
  - Does it appear when you tab to it?
  - Does it disappear when you tab out of it?
  - Does `Skip to main content` direct you to the `h1`?
  - Does `Skip to Ask a Librarian chat` direct you to the `m-chat`?
