### PR TITLE
Responsive Table

### DIFF
--- a/public/browse.css
+++ b/public/browse.css
@@ -226,60 +226,60 @@ nav.pagination m-icon svg {
 /*
   Browse table
 */
-table.m-table {
+table.browse-table {
   border-collapse: collapse;
   border-spacing: 0;
   text-align: left;
   width: 100%;
 }
 
-.m-table tr > * {
+.browse-table tr > * {
   border-top: solid var(--space-xxx-small) var(--search-neutral-400);
   padding: var(--space-medium) 0;
   vertical-align: top;
 }
 
-.m-table tr > *:not(:last-child) {
+.browse-table tr > *:not(:last-child) {
   padding-right: var(--space-x-large);
 }
 
-.m-table th:not([scope^='row']) {
+.browse-table th:not([scope^='row']) {
   border-top: 0;
 }
 
-.m-table th,
-.m-table td:first-of-type {
+.browse-table th,
+.browse-table td:first-of-type {
   white-space: nowrap;
 }
 
-.m-table tr[class^="match-"] > * {
+.browse-table tr[class^="match-"] > * {
   background: var(--search-neutral-200);
   padding: var(--space-small);
 }
 
-.m-table tr.match-notice > * {
+.browse-table tr.match-notice > * {
   background: var(--color-maize-200);
   border-color: var(--color-maize-300);
 }
 
-.m-table tr.match-notice + tr > td {
+.browse-table tr.match-notice + tr > td {
   border-color: var(--color-maize-300);
 }
 
-.m-table td > * {
+.browse-table td > * {
   margin: 0;
 }
 
-.m-table td a {
+.browse-table td a {
   font-weight: var(--semibold);
 }
 
-.m-table td p {
+.browse-table td p {
   font-size: 0.875em;
 }
 
 @media only screen and (max-width: 720px) {
-  .m-table thead {
+  .browse-table thead {
     position: absolute !important;
     height: 1px;
     width: 1px;
@@ -288,15 +288,15 @@ table.m-table {
     clip: rect(1px, 1px, 1px, 1px);
   }
 
-  .m-table tr > * {
+  .browse-table tr > * {
     display: block;
   }
 
-  .m-table tr > *:not(:first-child) {
+  .browse-table tr > *:not(:first-child) {
     border-top: 0;
   }
 
-  .m-table tr > *:not(:last-child) {
+  .browse-table tr > *:not(:last-child) {
     padding-bottom: 0;
     padding-right: 0;
   }

--- a/public/browse.css
+++ b/public/browse.css
@@ -21,13 +21,8 @@ body {
   --search-neutral-700: #262626;
 
   --search-font: 'Source Sans Pro';
-}
-
-/*
-  Search Product Typography
-*/
-body,
-h1 {
+  
+  color: var(--search-neutral-600);
   font-family: var(--search-font);
 }
 
@@ -70,12 +65,17 @@ body {
 
 
 h1 {
-  font-weight: 400;
+  font-family: inherit;
   font-size: 2rem;
+  font-weight: 400;
 }
 
 h1#maincontent {
   margin-top: var(--space-xx-large);
+}
+
+.strong {
+  font-weight: var(--bold);
 }
 
 .search-box {
@@ -234,7 +234,7 @@ table.m-table {
 }
 
 .m-table tr > * {
-  border-bottom: solid 1px var(--color-neutral-100);
+  border-top: solid var(--space-xxx-small) var(--search-neutral-400);
   padding: var(--space-medium) 0;
   vertical-align: top;
 }
@@ -243,20 +243,27 @@ table.m-table {
   padding-right: var(--space-x-large);
 }
 
-.m-table th {
-  font-size: var(--text-xxx-small);
-  letter-spacing: 1.25px;
-  text-transform: uppercase;
-  vertical-align: middle;
-}
-
 .m-table th:not([scope^='row']) {
-  border-bottom: solid var(--space-xxx-small) var(--color-maize-400);
+  border-top: 0;
 }
 
 .m-table th,
 .m-table td:first-of-type {
   white-space: nowrap;
+}
+
+.m-table tr[class^="match-"] > * {
+  background: var(--search-neutral-200);
+  padding: var(--space-small);
+}
+
+.m-table tr.match-notice > * {
+  background: var(--color-maize-200);
+  border-color: var(--color-maize-300);
+}
+
+.m-table tr.match-notice + tr > td {
+  border-color: var(--color-maize-300);
 }
 
 .m-table td > * {
@@ -265,6 +272,10 @@ table.m-table {
 
 .m-table td a {
   font-weight: var(--semibold);
+}
+
+.m-table td p {
+  font-size: 0.875em;
 }
 
 @media only screen and (max-width: 720px) {
@@ -281,8 +292,11 @@ table.m-table {
     display: block;
   }
 
+  .m-table tr > *:not(:first-child) {
+    border-top: 0;
+  }
+
   .m-table tr > *:not(:last-child) {
-    border-bottom: 0;
     padding-bottom: 0;
     padding-right: 0;
   }

--- a/public/browse.css
+++ b/public/browse.css
@@ -226,25 +226,66 @@ nav.pagination m-icon svg {
 /*
   Browse table
 */
-
-.browse-table th {
-  color: var(--search-neutral-600);
+table.m-table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  text-align: left;
+  width: 100%;
 }
 
-.browse-table a {
-  font-weight: 600;
+.m-table tr > * {
+  border-bottom: solid 1px var(--color-neutral-100);
+  padding: var(--space-medium) 0;
+  vertical-align: top;
 }
 
-.browse-table a ~ p {
+.m-table tr > *:not(:last-child) {
+  padding-right: var(--space-x-large);
+}
+
+.m-table th {
+  font-size: var(--text-xxx-small);
+  letter-spacing: 1.25px;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
+.m-table th:not([scope^='row']) {
+  border-bottom: solid var(--space-xxx-small) var(--color-maize-400);
+}
+
+.m-table th,
+.m-table td:first-of-type {
+  white-space: nowrap;
+}
+
+.m-table td > * {
   margin: 0;
 }
 
-.browse-table td {
-  border-width: 2px;
+.m-table td a {
+  font-weight: var(--semibold);
 }
 
-.browse-table tr:nth-child(2) td {
-  border: none;
+@media only screen and (max-width: 720px) {
+  .m-table thead {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px);
+  }
+
+  .m-table tr > * {
+    display: block;
+  }
+
+  .m-table tr > *:not(:last-child) {
+    border-bottom: 0;
+    padding-bottom: 0;
+    padding-right: 0;
+  }
 }
 
 /* global focus styles */

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -78,7 +78,7 @@ html lang="en"
               | Next page
               m-icon name="keyboard-arrow-right"
 
-      table class="table browse-table" cellspacing="0"
+      table class="m-table"
         thead
           tr
             th Call number

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -78,7 +78,7 @@ html lang="en"
               | Next page
               m-icon name="keyboard-arrow-right"
 
-      table class="m-table"
+      table class="browse-table"
         thead
           tr
             th Call number

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -85,20 +85,18 @@ html lang="en"
             th Item
         tbody
           - list.items.each do |result|
-            tr
-              - if result.match_notice? && list.num_matches == 1
-                td colspan="2" style="background: var(--color-maize-200); padding: var(--space-small); border: solid 2px var(--color-maize-300);"
-                  | We found a matching call number in our catalog for: 
-                  strong = list.original_reference
-              - elsif result.match_notice? && list.num_matches == 0 
-                td colspan="2" style="background: var(--search-neutral-200); padding: var(--space-small); border: solid 2px var(--search-neutral-100);"
-                  strong =list.original_reference
-                  |  would appear here. There's no exact match for that call number in our catalog. 
-              - elsif result.match_notice?
-                td colspan="2" style="background: var(--color-maize-200); padding: var(--space-small); border: solid 2px var(--color-maize-300);"
-                  | We found #{list.num_matches} matching items in our catalog for call number: 
-                  strong =list.original_reference
-              - else
+            - if result.match_notice?
+              tr class="match-#{list.num_matches == 0 ? "none" : "notice"}"
+                td colspan="2"
+                  - if list.num_matches == 1
+                    | We found a matching call number in our catalog for: 
+                  - elsif list.num_matches > 1
+                    | We found #{list.num_matches} matching items in our catalog for call number: 
+                  span class="strong" = list.original_reference
+                  - if list.num_matches == 0 
+                    |  would appear here. There's no exact match for that call number in our catalog. 
+            - else
+              tr
                 td = result.callnumber
                 td
                   a href=result.url = result.title


### PR DESCRIPTION
# Overview
Responsive styles have been added to the `table` containing browse results.

This pull request resolves `Success Criteria > 1` of [SEARCH-1524](https://tools.lib.umich.edu/jira/browse/SEARCH-1524).

## Anything else?
### `.m-table`
The Design System's `.m-table` styles have not yet been pushed to https://unpkg.com/@umich-lib/web@1.2.1/umich-lib.css, so interim styles have been added. 

### Match Notice
The `result.match_notice?` row and fields have been restructured for styling and to reduce repeated code. The notice does not show up for me, even when viewing on `main`, so I wasn't not able to fully test.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
