### PR TITLE
SEARCH-1525: Catalog Browse Header Content

### DIFF
--- a/public/browse.css
+++ b/public/browse.css
@@ -54,7 +54,7 @@ m-website-header a {
 
 m-website-header a:hover {
   text-decoration: underline;
-  text-underline-offset: 2px;
+  text-underline-offset: var(--space-xxx-small);
 }
 
 /*

--- a/public/browse.css
+++ b/public/browse.css
@@ -32,6 +32,30 @@ body {
   grid-template-rows: auto auto auto auto 1fr auto;
 }
 
+/*
+  Website Header
+*/
+
+m-website-header .website-header-inner-container {
+  margin: 0 calc(-1 * var(--space-small));
+}
+
+@media only screen and (max-width: 720px) {
+  m-website-header .website-header-inner-container {
+    margin-top: var(--space-small);
+  }
+}
+
+m-website-header a {
+  color: white;
+  text-decoration: none;
+  padding: var(--space-small);
+}
+
+m-website-header a:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
 
 /*
   Text

--- a/public/browse.css
+++ b/public/browse.css
@@ -40,16 +40,11 @@ m-website-header .website-header-inner-container {
   margin: 0 calc(-1 * var(--space-small));
 }
 
-@media only screen and (max-width: 720px) {
-  m-website-header .website-header-inner-container {
-    margin-top: var(--space-small);
-  }
-}
-
 m-website-header a {
   color: white;
+  display: inline-block;
   text-decoration: none;
-  padding: var(--space-small);
+  padding: var(--space-xx-small) var(--space-small);
 }
 
 m-website-header a:hover {

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -19,9 +19,9 @@ html lang="en"
     m-universal-header
     
     m-website-header name="Search" to="https://search.lib.umich.edu/" variant="dark"
-      div role="presenation"
-        a href="https://apps.lib.umich.edu/my-account"
-        a href="https://apps.lib.umich.edu/my-account/favorites"
+      div role="presenation" class="website-header-inner-container"
+        a href="https://apps.lib.umich.edu/my-account" Account
+        a href="https://apps.lib.umich.edu/my-account/favorites" Favorites
 
     form class="search-box" role="search" method="get"
       div class="viewport-container"

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -21,7 +21,7 @@ html lang="en"
     m-website-header name="Search" to="https://search.lib.umich.edu/" variant="dark"
       div role="presenation" class="website-header-inner-container"
         a href="https://apps.lib.umich.edu/my-account" Account
-        a href="https://apps.lib.umich.edu/my-account/favorites" Favorites
+        a href="https://apps.lib.umich.edu/my-account/favorites" My Favorites
 
     form class="search-box" role="search" method="get"
       div class="viewport-container"

--- a/views/browse.slim
+++ b/views/browse.slim
@@ -19,6 +19,9 @@ html lang="en"
     m-universal-header
     
     m-website-header name="Search" to="https://search.lib.umich.edu/" variant="dark"
+      div role="presenation"
+        a href="https://apps.lib.umich.edu/my-account"
+        a href="https://apps.lib.umich.edu/my-account/favorites"
 
     form class="search-box" role="search" method="get"
       div class="viewport-container"


### PR DESCRIPTION
# Overview
Reimplement the Library Search Website Header in the Catalog Browse Website Header since that needs to be recreated because Catalog Browse is it's own Sinatra app.

This pull request will close: https://tools.lib.umich.edu/jira/browse/SEARCH-1525

## Preview Screenshots

Small viewport: https://user-images.githubusercontent.com/1678665/143902489-237bae39-2638-4458-9881-6789ef672ec5.png

Large viewport: https://user-images.githubusercontent.com/1678665/143902506-f1eb3517-ce16-40a0-afa2-a4ad2548bf5a.png


