### PR TITLE
Exact match styling

### DIFF
--- a/public/browse.css
+++ b/public/browse.css
@@ -76,7 +76,7 @@ a {
 
 a:hover,
 a:focus {
-  text-decoration-thickness: 2px;
+  text-decoration-thickness: var(--space-xxx-small);
 }
 
 /*

--- a/public/browse.css
+++ b/public/browse.css
@@ -310,6 +310,10 @@ table.browse-table {
   background: var(--color-teal-100);
 }
 
+.browse-table tbody tr > *:first-of-type {
+  border-top-width: var(--space-xxx-small);
+}
+
 .browse-table tr > * + * {
   padding-top: 0;
 }
@@ -344,6 +348,10 @@ table.browse-table {
 
   .browse-table tr > * {
     display: table-cell;
+  }
+
+  .browse-table tbody tr > * {
+    border-top-width: var(--space-xxx-small);
   }
 
   .browse-table tr > * + * {

--- a/public/browse.css
+++ b/public/browse.css
@@ -285,12 +285,8 @@ table.browse-table {
 
 .browse-table tr > * {
   border-top: solid var(--space-xxx-small) var(--search-neutral-400);
-  padding: var(--space-medium) 0;
+  padding: var(--space-small) var(--space-medium);
   vertical-align: top;
-}
-
-.browse-table tr > *:not(:last-child) {
-  padding-right: var(--space-x-large);
 }
 
 .browse-table th:not([scope^='row']) {
@@ -310,7 +306,6 @@ table.browse-table {
 
 .browse-table tr[class^="match-"] > * {
   background: var(--search-neutral-200);
-  padding: var(--space-small);
 }
 
 .browse-table tr.match-notice > * {
@@ -331,6 +326,11 @@ table.browse-table {
 }
 
 @media only screen and (max-width: 719px) {
+  table.browse-table {
+    margin-left: calc(var(--viewport-margin) * -1);
+    margin-right: calc(var(--viewport-margin) * -1);
+    width: calc(var(--viewport-margin) * 2 + 100%);
+  }
   .browse-table thead {
     position: absolute !important;
     height: 1px;

--- a/public/browse.css
+++ b/public/browse.css
@@ -324,6 +324,10 @@ table.browse-table {
   background: var(--color-teal-100);
 }
 
+.browse-table tr.exact-match + tr > * {
+  border-top-color: var(--color-teal-400);
+}
+
 .browse-table tbody tr > *:first-of-type {
   border-top-width: var(--space-xxx-small);
 }

--- a/public/browse.css
+++ b/public/browse.css
@@ -302,8 +302,22 @@ table.browse-table {
   vertical-align: top;
 }
 
+.browse-table tr:last-child > *:last-child {
+  border-bottom-width: var(--space-xxx-small);
+}
+
+.browse-table tr[class] > * {
+  border-left-width: var(--space-xxx-small);
+  border-right-width: var(--space-xxx-small);
+}
+
 .browse-table tr[class^="match-"] > * {
   background: var(--search-neutral-200);
+}
+
+.browse-table tr.match-notice > *,
+.browse-table tr.exact-match > * {
+  border-color: var(--color-teal-400);
 }
 
 .browse-table tr.match-notice > * {
@@ -342,7 +356,6 @@ table.browse-table {
   }
 
   .browse-table thead tr > * {
-    border-bottom-width: var(--space-xxx-small);
     border-color: var(--color-maize-400);
   }
 
@@ -350,8 +363,20 @@ table.browse-table {
     display: table-cell;
   }
 
+  .browse-table tr:last-child > * {
+    border-bottom-width: var(--space-xxx-small);
+  }
+
   .browse-table tbody tr > * {
     border-top-width: var(--space-xxx-small);
+  }
+
+  .browse-table tbody tr > *:not(:first-child) {
+    border-left: 0;
+  }
+
+  .browse-table tbody tr > *:not(:last-child) {
+    border-right: 0;
   }
 
   .browse-table tr > * + * {

--- a/public/browse.css
+++ b/public/browse.css
@@ -294,6 +294,9 @@ table.browse-table {
 }
 
 .browse-table tr > * {
+  border-color: var(--search-neutral-400);
+  border-style: solid;
+  border-width: 0;
   display: block;
   padding: var(--space-small) var(--space-medium);
   vertical-align: top;

--- a/public/browse.css
+++ b/public/browse.css
@@ -279,29 +279,24 @@ nav.pagination m-icon svg {
 table.browse-table {
   border-collapse: collapse;
   border-spacing: 0;
+  margin: 0 calc(var(--viewport-margin) * -1);
   text-align: left;
-  width: 100%;
+  width: calc(var(--viewport-margin) * 2 + 100%);
+}
+
+.browse-table thead {
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
 }
 
 .browse-table tr > * {
-  border-top: solid var(--space-xxx-small) var(--search-neutral-400);
+  display: block;
   padding: var(--space-small) var(--space-medium);
   vertical-align: top;
-}
-
-.browse-table th:not([scope^='row']) {
-  border-top: 0;
-}
-
-.browse-table th,
-.browse-table td:first-of-type:not([colspan]) {
-  white-space: nowrap;
-}
-
-@media only screen and (min-width: 720px) {
-  .browse-table td:first-of-type:not([colspan]) {
-    width: 200px;
-  }
 }
 
 .browse-table tr[class^="match-"] > * {
@@ -309,12 +304,16 @@ table.browse-table {
 }
 
 .browse-table tr.match-notice > * {
-  background: var(--color-maize-200);
-  border-color: var(--color-maize-300);
+  background: var(--color-teal-100);
 }
 
-.browse-table tr.match-notice + tr > td {
-  border-color: var(--color-maize-300);
+.browse-table tr > * + * {
+  padding-top: 0;
+}
+
+.browse-table th,
+.browse-table td:first-of-type:not([colspan]) {
+  white-space: nowrap;
 }
 
 .browse-table td > * {
@@ -325,32 +324,26 @@ table.browse-table {
   font-weight: var(--semibold);
 }
 
-@media only screen and (max-width: 719px) {
+@media only screen and (min-width: 720px) {
   table.browse-table {
-    margin-left: calc(var(--viewport-margin) * -1);
-    margin-right: calc(var(--viewport-margin) * -1);
-    width: calc(var(--viewport-margin) * 2 + 100%);
+    margin: 0;
+    width: 100%;
   }
+
   .browse-table thead {
-    position: absolute !important;
-    height: 1px;
-    width: 1px;
-    overflow: hidden;
-    clip: rect(1px 1px 1px 1px);
-    clip: rect(1px, 1px, 1px, 1px);
+    all: revert;
   }
 
   .browse-table tr > * {
-    display: block;
+    display: table-cell;
   }
 
-  .browse-table tr > *:not(:first-child) {
-    border-top: 0;
+  .browse-table tr > * + * {
+    padding-top: var(--space-small);
   }
 
-  .browse-table tr > *:not(:last-child) {
-    padding-bottom: 0;
-    padding-right: 0;
+  .browse-table td:first-of-type:not([colspan]) {
+    width: 200px;
   }
 }
 

--- a/public/browse.css
+++ b/public/browse.css
@@ -337,6 +337,11 @@ table.browse-table {
     all: revert;
   }
 
+  .browse-table thead tr > * {
+    border-bottom-width: var(--space-xxx-small);
+    border-color: var(--color-maize-400);
+  }
+
   .browse-table tr > * {
     display: table-cell;
   }

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -35,10 +35,12 @@
             <% fields.each do |group| %>
               <optgroup label="<%=group[:label]%>">
                 <% group[:options].each do |option| %>
-                  <option <%=option[:disabled]%> <%=option[:selected]%> value="<%=option[:value]%>"><%=option[:label]%></option>
+                  <option <%=option[:disabled]%> <%=option[:selected]%> value="<%=option[:value]%>">
+                    <%=option[:label]%>
+                  </option>
                 <% end %>
+              </optgroup>
             <% end %>
-                   
           </select>
           <m-icon name="keyboard-arrow-down"></m-icon>
         </div>


### PR DESCRIPTION
# Overview
This pull request updates the styling of exact matches according to the [Figma design](https://www.figma.com/file/ymqm7jMhh1xFIONkNZZrcB/?node-id=0%3A9201).

## Anything else?
I have changed the media queries so it is now mobile-first.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
