### PR TITLE
[SEARCH-1505] Add search hint/help suggestions to the Catalog Browse UI

### DIFF
--- a/config/search_dropdown.yml
+++ b/config/search_dropdown.yml
@@ -32,9 +32,9 @@
 - :label: Browse by
   :tip: Browse Tip
   :options:
-  - :label: Browse by LC call number
-    :value: browse_by_lc_callnumber
-    :tip: Browse by Library of Congress (LC) call number, sorted alphanumerically. Learn about the meaning of call numbers. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers<span class="visually-hidden"> (link points to external site)</span></a>.
+  - :label: Browse by call number (LC and Dewey)
+    :value: browse_by_callnumber
+    :tip: Browse by Library of Congress (LC) and Dewey call numbers, sorted alphanumerically. Learn about the meaning of call numbers. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers<span class="visually-hidden"> (link points to external site)</span></a>.
     :selected: selected
   - :label: Browse by author (coming soon)
     :value: browse_by_author

--- a/config/search_dropdown.yml
+++ b/config/search_dropdown.yml
@@ -36,7 +36,15 @@
     :value: browse_by_lc_callnumber
     :tip: Browse by Library of Congress (LC) call number, sorted alphanumerically. Learn about the meaning of call numbers. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers <span class="visually-hidden">(link redirects to external site)</span></a>.
     :selected: selected
+  - :label: Browse by author (coming soon)
+    :value: browse_by_author
+    :tip: Browse an alphabetical list of authors. Authors can be people (put last names first), organizations, or events. (e.g. Kingston, Maxine Hong; United Nations Development Programme; Pong, Chun-ho)
+    :disabled: disabled
   - :label: Browse by subject (coming soon)
     :value: browse_by_subject
     :tip: Browse an A-Z list of subjects. (e.g. motion pictures; history--United States; Eliot, George)
+    :disabled: disabled
+  - :label: Browse by title (coming soon)
+    :value: browse_by_title
+    :tip: Browse an alphabetical list of titles for books, online journals, serials, media, etc. (Nine stories; Tom Swift and )
     :disabled: disabled

--- a/config/search_dropdown.yml
+++ b/config/search_dropdown.yml
@@ -4,7 +4,7 @@
   :options:
   - :label: Keyword
     :value: keyword
-    :tip: Enter one or more keywords. se quotes to search for a phrase. (e.g. solar power; polar bears; “systems of oppression”) See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching <span class="visually-hidden">(link redirects to external site)</span></a>.
+    :tip: Enter one or more keywords. Use quotes to search for a phrase. (e.g. solar power; polar bears; “systems of oppression”) See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching <span class="visually-hidden">(link redirects to external site)</span></a>.
   - :label: Title
     :value: title
     :tip: Enter the first words in a title. Use quotes to search a phrase. (e.g. One Hundred Years of Solitude; “The Fourth World”; Disability Visibility)

--- a/config/search_dropdown.yml
+++ b/config/search_dropdown.yml
@@ -1,29 +1,42 @@
 ---
 - :label: Search by
+  :tip: Search Tip
   :options:
   - :label: Keyword
     :value: keyword
+    :tip: Enter one or more keywords. se quotes to search for a phrase. (e.g. solar power; polar bears; “systems of oppression”) See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching <span class="visually-hidden">(link redirects to external site)</span></a>.
   - :label: Title
     :value: title
+    :tip: Enter the first words in a title. Use quotes to search a phrase. (e.g. One Hundred Years of Solitude; “The Fourth World”; Disability Visibility)
   - :label: Author
     :value: author
+    :tip: Search for items by author or contributor. Also search organizations or corporate authors. (e.g. Kimmerer, Robin Wall; American Medical Association; 小川 洋子)
   - :label: Journal/Serial Title
     :value: journal_title
+    :tip: Search the title of a journal or serial publication. (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers)
   - :label: Academic Discipline
     :value: academic_discipline
+    :tip: Search academic disciplines. <a href="https://search.lib.umich.edu/databases/browse?query=sculpture">Browse all Databases</a> alphabetically or by academic discipline. (e.g. International business; Latin american and caribbean studies)
   - :label: Call Number starts with
     :value: call_number_starts_with
+    :tip: Search the first few letters and numbers of a call number. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers <span class="visually-hidden">(link redirects to external site)</span></a>.
   - :label: Series (transcribed)
     :value: series
+    :tip: Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series. (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music)
   - :label: Year of Publication
     :value: publication_date
+    :tip: Search by year (YYYY) (e.g. 2021, 1942)
   - :label: ISBN/ISSN/OCLC/etc
     :value: isn
+    :tip: Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number. (e.g.  0040-781X; 0747581088; 921446069)
 - :label: Browse by
+  :tip: Browse Tip
   :options:
   - :label: Browse by LC call number
     :value: browse_by_lc_callnumber
+    :tip: Browse by Library of Congress (LC) call number, sorted alphanumerically. Learn about the meaning of call numbers. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers <span class="visually-hidden">(link redirects to external site)</span></a>.
     :selected: selected
   - :label: Browse by subject (coming soon)
     :value: browse_by_subject
+    :tip: Browse an A-Z list of subjects. (e.g. motion pictures; history--United States; Eliot, George)
     :disabled: disabled

--- a/config/search_dropdown.yml
+++ b/config/search_dropdown.yml
@@ -4,7 +4,7 @@
   :options:
   - :label: Keyword
     :value: keyword
-    :tip: Enter one or more keywords. Use quotes to search for a phrase. (e.g. solar power; polar bears; “systems of oppression”) See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching <span class="visually-hidden">(link redirects to external site)</span></a>.
+    :tip: Enter one or more keywords. Use quotes to search for a phrase. (e.g. solar power; polar bears; “systems of oppression”) See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.
   - :label: Title
     :value: title
     :tip: Enter the first words in a title. Use quotes to search a phrase. (e.g. One Hundred Years of Solitude; “The Fourth World”; Disability Visibility)
@@ -19,7 +19,7 @@
     :tip: Search academic disciplines. <a href="https://search.lib.umich.edu/databases/browse?query=sculpture">Browse all Databases</a> alphabetically or by academic discipline. (e.g. International business; Latin american and caribbean studies)
   - :label: Call Number starts with
     :value: call_number_starts_with
-    :tip: Search the first few letters and numbers of a call number. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers <span class="visually-hidden">(link redirects to external site)</span></a>.
+    :tip: Search the first few letters and numbers of a call number. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers<span class="visually-hidden"> (link points to external site)</span></a>.
   - :label: Series (transcribed)
     :value: series
     :tip: Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series. (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music)
@@ -34,7 +34,7 @@
   :options:
   - :label: Browse by LC call number
     :value: browse_by_lc_callnumber
-    :tip: Browse by Library of Congress (LC) call number, sorted alphanumerically. Learn about the meaning of call numbers. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers <span class="visually-hidden">(link redirects to external site)</span></a>.
+    :tip: Browse by Library of Congress (LC) call number, sorted alphanumerically. Learn about the meaning of call numbers. (e.g. RC662.4 .H38 2016; QH 105) <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers<span class="visually-hidden"> (link points to external site)</span></a>.
     :selected: selected
   - :label: Browse by author (coming soon)
     :value: browse_by_author

--- a/lib/models/search_dropdown.rb
+++ b/lib/models/search_dropdown.rb
@@ -15,7 +15,7 @@ end
 class SearchDropdown::Browse < SearchDropdown
   def url
     case @type
-    when "browse_by_lc_callnumber"
+    when "browse_by_callnumber"
       "#{ENV.fetch("BASE_URL")}/callnumber?query=#{encoded_query}"
     else
       #Users shouldn't be able to do this; 

--- a/public/browse.css
+++ b/public/browse.css
@@ -228,7 +228,7 @@ m-icon svg {
   }
 
   .search-box .search-box-dropdown {
-    max-width: 280px;
+    max-width: 320px;
   }
 
   .search-box select {

--- a/public/browse.css
+++ b/public/browse.css
@@ -141,6 +141,7 @@ m-icon svg {
 
 .search-box .viewport-container > * {
   flex: 1 1 auto;
+  margin-bottom: 0;
   margin-top: var(--space-small);
 }
 
@@ -205,6 +206,20 @@ m-icon svg {
 .search-box button:active {
   background: var(--search-blue-500);
   border-bottom-color: var(--search-blue-600);
+}
+
+.search-box .search-tip {
+  flex-wrap: nowrap;
+}
+
+.search-box .search-tip > m-icon {
+  flex-grow: 0;
+  margin-right: var(--space-small);
+  padding-top: var(--space-xx-small);
+}
+
+.search-box .search-tip m-icon svg {
+  width: var(--space-medium);
 }
 
 @media only screen and (min-width: 720px) {

--- a/public/browse.js
+++ b/public/browse.js
@@ -1,0 +1,12 @@
+/*
+ * Select Dropdown Tips
+ */
+const selectDropdown = document.querySelector('.search-box-dropdown select');
+const getOptionTips = document.querySelectorAll('p[data-option]');
+
+selectDropdown.addEventListener('change', (event) => {
+  getOptionTips.forEach((optionTip) => {
+    const getDataOption = optionTip.getAttribute('data-option');
+    optionTip.style.display = getDataOption === event.target.value ? 'initial' : 'none';
+  });
+});

--- a/public/browse.js
+++ b/public/browse.js
@@ -2,11 +2,11 @@
  * Select Dropdown Tips
  */
 const selectDropdown = document.querySelector('.search-box-dropdown select');
-const getOptionTips = document.querySelectorAll('p[data-option]');
+const optionTips = document.querySelectorAll('p[data-option]');
 
 selectDropdown.addEventListener('change', (event) => {
-  getOptionTips.forEach((optionTip) => {
-    const getDataOption = optionTip.getAttribute('data-option');
-    optionTip.style.display = getDataOption === event.target.value ? 'initial' : 'none';
+  optionTips.forEach((optionTip) => {
+    const dataOptionValue = optionTip.getAttribute('data-option');
+    optionTip.style.display = dataOptionValue === event.target.value ? 'initial' : 'none';
   });
 });

--- a/spec/models/search_dropdown_spec.rb
+++ b/spec/models/search_dropdown_spec.rb
@@ -14,7 +14,7 @@ describe SearchDropdown, "#url" do
     expect(subject).to eq("https://search.lib.umich.edu/catalog?query=#{encoded_query("keyword:(Things)")}")
   end
   it "returns appropriate browse url" do
-    @type = 'browse_by_lc_callnumber'
+    @type = 'browse_by_callnumber'
     expect(subject).to eq("#{ENV.fetch("BASE_URL")}/callnumber?query=#{encoded_query("Things")}")
   end
   it "sends the user to search if they submit nonexistent browse_by type" do

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -78,7 +78,7 @@
     <main class="viewport-container">
       <h1 id="maincontent" tabindex="-1">
         <% if list.original_reference != '' %>
-          Browse `<%= list.original_reference %>` in call numbers
+          Browse "<%= list.original_reference %>" in call numbers
         <% else %>
           Browse by Call Number (Library of Congress and Dewey)
         <% end %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -50,6 +50,17 @@
           <span class="visually-hidden">Search</span>
         </button>
       </div>
+      <div class="viewport-container search-tip">
+        <m-icon name="info-outline"></m-icon>
+        <% fields.each do |group| %>
+          <% group[:options].each do |option| %>
+            <p data-option="<%=option[:value]%>" style="display: <%= option[:selected] ? 'initial' : 'none' %>;">
+              <span class="strong"><%=group[:tip]%>:</span>
+              <%=option[:tip]%>
+            </p>
+          <% end %>
+        <% end %>
+      </div>
     </form>
     <div class="datastores-nav">
       <nav class="viewport-container" aria-label="Datastores">
@@ -151,5 +162,6 @@
     <m-chat>
       <div id="chat" tabindex="-1"></div>
     </m-chat>
+    <script src="/browse.js"></script>
   </body>
 </html>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -78,8 +78,8 @@
     <main class="viewport-container">
       <h1 id="maincontent" tabindex="-1">
         <% if list.original_reference != '' %>
-        Browse `<%= list.original_reference %>` in call numbers
-      <% else %>
+          Browse `<%= list.original_reference %>` in call numbers
+        <% else %>
           Browse by LC Callnumber
         <% end %>
       </h1>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Library Search | Browse by call number</title>
+    <title>Library Search | Browse by Call Number (Library of Congress and Dewey)</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <link rel="stylesheet" href="https://unpkg.com/@umich-lib/web@1/umich-lib.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">
@@ -80,12 +80,12 @@
         <% if list.original_reference != '' %>
           Browse `<%= list.original_reference %>` in call numbers
         <% else %>
-          Browse by LC Callnumber
+          Browse by Call Number (Library of Congress and Dewey)
         <% end %>
       </h1>
       <p>
         <span class="strong">Browse by call number help:</span> 
-        Search a Library of Congress (LC) call number and view an alphabetical list of all LC call numbers and related titles indexed in the Library catalog.
+        Search a Library of Congress (LC) or Dewey call number and view an alphabetical list of all call numbers and related titles indexed in the Library catalog.
       </p>
     <% if list.original_reference != '' %>
       <%= erb :'components/pagination', locals: {label: 'Top pagination', list: list} %>


### PR DESCRIPTION
# Overview
When a user selects an option from the dropdown menu, a tip will appear under the form to help show the user how to properly search or browse for an item. This tip will appear under the search form.

This pull request resolves the `Catalog` portion of [SEARCH-1505](https://tools.lib.umich.edu/jira/browse/SEARCH-1505).

## SEARCH-1538
Browse now has updated text that is inclusive of Dewey call numbers.

This pull request resolves the `Catalog` portion of [SEARCH-1538](https://tools.lib.umich.edu/jira/browse/SEARCH-1538).

## SEARCH-1539
The back-ticks that surround the call number have been changed to double-quotes.

This pull request resolves [SEARCH-1539](https://tools.lib.umich.edu/jira/browse/SEARCH-1539).

## Anything else?
To lessen future work, the remaining upcoming browse options have been added to the dropdown. The [tips are still in draft](https://docs.google.com/document/d/1BtG67b41-KxX5wnDE3bI1EJ6THZPHFkOOcBSMqRDSls/edit?usp=sharing), so they will most likely be updated in the future.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- On [localhost](http://localhost:4567/callnumber), check the tip under the search form.
  - Does the tip for the default selected option appear on load?
  - When you select a different option, does the tip change?
  - Does the tip change when you try to select a disabled option?