### PR TITLE
[SEARCH-1533] Show both transliterated and vernacular data where it is available

### DIFF
--- a/lib/models/browse_item.rb
+++ b/lib/models/browse_item.rb
@@ -15,29 +15,11 @@ class BrowseItem
     "https://search.lib.umich.edu/catalog/record/#{mms_id}"
   end
   def title
-    [bib_title, author].join(" ") 
+    [@catalog_doc["title_display"]&.first, edition].compact.join(" ")
   end
   def vernacular_title
-    [vernacular_bib_title, vernacular_author].join(" ")
-  end
-  def callnumber
-    @index_doc["callnumber"]&.strip
-  end
-  def subtitles
-    [ author, publisher].compact
-  end
-  
-
-  private
-  #component pieces
-  def mms_id
-    @index_doc["bib_id"]
-  end
-  def bib_title
-    @catalog_doc["title_display"]&.first
-  end
-  def vernacular_bib_title
-    @catalog_doc["title_display"]&.slice(1)
+    output = @catalog_doc["title_display"]&.slice(1)
+    [output, edition].compact.join(" ") unless output.nil?
   end
   def author
     @catalog_doc["mainauthor"]&.first
@@ -45,7 +27,36 @@ class BrowseItem
   def vernacular_author
     @catalog_doc["mainauthor"]&.slice(1)
   end
+  def callnumber
+    @index_doc["callnumber"]&.strip
+  end
+  def subtitles
+    [ author, publisher].compact
+  end
   def publisher
     @catalog_doc["publisher"]&.first
   end
+  def vernacular_publisher
+    @catalog_doc["publisher"]&.slice(1)
+  end
+  
+
+  private
+  #component pieces
+  def edition
+    @catalog_doc["edition"]&.first
+  end
+  def mms_id
+    @index_doc["bib_id"]
+  end
+  def bib_title
+    @catalog_doc["title_display"]&.first
+  end
+  def bib_edition
+    @catalog_doc["edition"]
+  end
+  def vernacular_bib_title
+    @catalog_doc["title_display"]&.slice(1)
+  end
+  #publish brief?
 end

--- a/lib/models/browse_item.rb
+++ b/lib/models/browse_item.rb
@@ -49,14 +49,4 @@ class BrowseItem
   def mms_id
     @index_doc["bib_id"]
   end
-  def bib_title
-    @catalog_doc["title_display"]&.first
-  end
-  def bib_edition
-    @catalog_doc["edition"]
-  end
-  def vernacular_bib_title
-    @catalog_doc["title_display"]&.slice(1)
-  end
-  #publish brief?
 end

--- a/lib/models/browse_item.rb
+++ b/lib/models/browse_item.rb
@@ -11,6 +11,9 @@ class BrowseItem
     !!@exact_match
   end
   #for the view
+  def callnumber
+    @index_doc["callnumber"]&.strip
+  end
   def url
     "https://search.lib.umich.edu/catalog/record/#{mms_id}"
   end
@@ -27,11 +30,17 @@ class BrowseItem
   def vernacular_author
     @catalog_doc["mainauthor"]&.slice(1)
   end
-  def callnumber
-    @index_doc["callnumber"]&.strip
+  def author
+    catalog_data("mainauthor")
   end
-  def subtitles
-    [ author, publisher].compact
+  def vernacular_author
+    catalog_data("mainauthor", true)
+  end
+  def publisher
+    catalog_data("publisher")
+  end
+  def vernacular_publisher
+    catalog_data("publisher", true)
   end
   def publisher
     @catalog_doc["publisher"]&.first

--- a/lib/models/browse_item.rb
+++ b/lib/models/browse_item.rb
@@ -30,18 +30,6 @@ class BrowseItem
   def vernacular_author
     @catalog_doc["mainauthor"]&.slice(1)
   end
-  def author
-    catalog_data("mainauthor")
-  end
-  def vernacular_author
-    catalog_data("mainauthor", true)
-  end
-  def publisher
-    catalog_data("publisher")
-  end
-  def vernacular_publisher
-    catalog_data("publisher", true)
-  end
   def publisher
     @catalog_doc["publisher"]&.first
   end

--- a/public/browse.css
+++ b/public/browse.css
@@ -25,7 +25,7 @@ html {
 }
 
 body {
-  color: var(--search-neutral-600);
+  color: var(--search-neutral-700);
   display: flex;
   flex-direction: column;
   font-family: 'Source Sans Pro', sans-serif;
@@ -443,6 +443,25 @@ table.browse-table {
   font-weight: var(--semibold);
 }
 
+.browse-table dl dt {
+  clear: left;
+  float: left;
+  font-weight: var(--semibold);
+  margin-right: var(--space-x-small);
+}
+
+.browse-table dl dd {
+  margin: 0;
+}
+
+.browse-table .vernacular {
+  color: var(--search-neutral-500);
+}
+
+.browse-table dl dd:first-of-type .vernacular {
+  display: block;
+}
+
 @media only screen and (min-width: 720px) {
   table.browse-table {
     margin: 0;
@@ -492,7 +511,7 @@ table.browse-table {
 
 .give-feedback a {
   align-items: center;
-  display: flex;
+  display: inline-flex;
   gap: var(--space-xx-small);
 }
 

--- a/spec/models/browse_item_spec.rb
+++ b/spec/models/browse_item_spec.rb
@@ -14,11 +14,35 @@ describe BrowseItem do
   it "shows appropriate url" do
     expect(subject.url).to eq("https://search.lib.umich.edu/catalog/record/990039902820106381")
   end
-  it "shows appropriate title" do
-    expect(subject.title).to eq("Zhiznʹ gospodina de Molʹera / M. Bulgakov ; [podgot. teksta i poslesl. V.I. Loseva]. Bulgakov, Mikhail, 1891-1940.")
+  context "#title" do
+    it "shows appropriate title without edition when there isn't one" do
+      expect(subject.title).to eq("Zhiznʹ gospodina de Molʹera / M. Bulgakov ; [podgot. teksta i poslesl. V.I. Loseva].")
+    end
+    it "shows title with edition when there is one" do
+      @catalog_doc["edition"] = ["my edition"]
+      expect(subject.title).to eq("Zhiznʹ gospodina de Molʹera / M. Bulgakov ; [podgot. teksta i poslesl. V.I. Loseva]. my edition")
+    end
   end
-  it "shows appropriate vernacular title" do
-    expect(subject.vernacular_title).to eq("Жизнь господина де Мольера / М. Булгаков ; [подгот. текста и послесл. В.И. Лосева]. Булгаков, Михаил, 1891-1940.")
+  context "#vernacular_title"  do
+    it "shows vernacular title without edition when there isn't one" do
+      expect(subject.vernacular_title).to eq("Жизнь господина де Мольера / М. Булгаков ; [подгот. текста и послесл. В.И. Лосева].")
+    end
+    it "shows vernacular title with edition when there is one" do
+      @catalog_doc["edition"] = ["my edition"]
+      expect(subject.vernacular_title).to eq("Жизнь господина де Мольера / М. Булгаков ; [подгот. текста и послесл. В.И. Лосева]. my edition")
+    end
+  end
+  it "shows appropriate author" do
+    expect(subject.author).to eq("Bulgakov, Mikhail, 1891-1940.")
+  end
+  it "shows appropriate vernacular author" do
+    expect(subject.vernacular_author).to eq("Булгаков, Михаил, 1891-1940.")
+  end
+  it "shows appropriate publisher" do
+    expect(subject.publisher).to eq("\"Delovoĭ t͡sentr\",")
+  end
+  it "shows appropriate vernacular publisher" do
+    expect(subject.vernacular_publisher).to eq("\"Деловой центр\",")
   end
   it "shows callnumber" do
     expect(subject.callnumber).to eq("PQ 1852 .B85 1992")

--- a/spec/models/browse_item_spec.rb
+++ b/spec/models/browse_item_spec.rb
@@ -11,6 +11,9 @@ describe BrowseItem do
   it "has false match_notice?" do
     expect(subject.match_notice?).to eq(false)
   end
+  it "shows callnumber" do
+    expect(subject.callnumber).to eq("PQ 1852 .B85 1992")
+  end
   it "shows appropriate url" do
     expect(subject.url).to eq("https://search.lib.umich.edu/catalog/record/990039902820106381")
   end
@@ -44,10 +47,16 @@ describe BrowseItem do
   it "shows appropriate vernacular publisher" do
     expect(subject.vernacular_publisher).to eq("\"Деловой центр\",")
   end
-  it "shows callnumber" do
-    expect(subject.callnumber).to eq("PQ 1852 .B85 1992")
+  it "shows appropriate author" do
+    expect(subject.author).to eq("Bulgakov, Mikhail, 1891-1940.")
   end
-  it "shows subtitles" do
-    expect(subject.subtitles).to eq(["Bulgakov, Mikhail, 1891-1940.","\"Delovoĭ t͡sentr\","])
+  it "shows appropriate vernacular author" do
+    expect(subject.vernacular_author).to eq("Булгаков, Михаил, 1891-1940.")
+  end
+  it "shows appropriate publisher" do
+    expect(subject.publisher).to eq("\"Delovoĭ t͡sentr\",")
+  end
+  it "shows appropriate vernacular publisher" do
+    expect(subject.vernacular_publisher).to eq("\"Деловой центр\",")
   end
 end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -112,10 +112,33 @@
                     </span>
                   </td>
                   <td>
-                    <a href="<%= result.url %>"><%= result.title %></a>
-                    <% result.subtitles.each do |subtitle| %>
-                      <p><%= subtitle %></p>
-                    <% end %>
+                    <dl>
+                      <dt class="visually-hidden">Title:</dt>
+                      <dd>
+                        <a href="<%= result.url %>"><%= result.title %></a>
+                        <% if result.vernacular_title %>
+                          <span class="vernacular"><%= result.vernacular_title %></span>
+                        <% end %>
+                      </dd>
+                      <% if result.author %>
+                        <dt>Main author:</dt>
+                        <dd>
+                          <%= result.author %>
+                          <% if result.vernacular_author %>
+                            <span class="vernacular">| <%= result.vernacular_author %></span>
+                          <% end %>
+                        </dd>
+                      <% end %>
+                      <% if result.publisher %>
+                        <dt>Published/Created:</dt>
+                        <dd>
+                          <%= result.publisher %>
+                          <% if result.vernacular_publisher %>
+                            <span class="vernacular">| <%= result.vernacular_publisher %></span>
+                          <% end %>
+                        </dd>
+                      <% end %>
+                    </dl>
                   </td>
                 </tr>
               <% end %>


### PR DESCRIPTION
# Overview
Each browse item will now display the vernacular data next to its transliterated data. All data (except the title) will now have a label next to it, to match the [Figma design](https://www.figma.com/file/ymqm7jMhh1xFIONkNZZrcB/?node-id=381%3A9747).

<img width="667" alt="Figma design with vernacular data" src="https://user-images.githubusercontent.com/27687379/146207035-6baebc38-29bf-4198-b1ea-5d02913b8181.png">

This pull request resolves/closes/fixes [JIRA-1533](https://tools.lib.umich.edu/jira/browse/JIRA-1533).

## Anything else?
SEARCH-1533 also lists adding `Series` in this issue, but the data doesn't get added until [JIRA-1534](https://tools.lib.umich.edu/jira/browse/JIRA-1534).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
  - Break the new/updated unit tests to make sure they're working properly.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Look up a call number with vernacular information to see it appear (e.g. `PL 799 .K3 Z5 K97`)
