### PR TITLE
[SEARCH-1534] Add display of series information

### DIFF
--- a/lib/models/browse_item.rb
+++ b/lib/models/browse_item.rb
@@ -36,6 +36,12 @@ class BrowseItem
   def vernacular_publisher
     @catalog_doc["publisher"]&.slice(1)
   end
+  def series
+    @catalog_doc["series"]&.first
+  end
+  def vernacular_series
+    @catalog_doc["series"]&.slice(1)
+  end
   
 
   private

--- a/spec/models/browse_item_spec.rb
+++ b/spec/models/browse_item_spec.rb
@@ -59,4 +59,10 @@ describe BrowseItem do
   it "shows appropriate vernacular publisher" do
     expect(subject.vernacular_publisher).to eq("\"Деловой центр\",")
   end
+  it "shows appropriate series" do
+    expect(subject.series).to eq("Zagadki i taĭny sudʹby")
+  end
+  it "shows appropriate vernacular series" do
+    expect(subject.vernacular_series).to eq("Загадки и тайны судьбы.")
+  end
 end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -121,7 +121,7 @@
                         <% end %>
                       </dd>
                       <% if result.author %>
-                        <dt>Main author:</dt>
+                        <dt>Main Author:</dt>
                         <dd>
                           <%= result.author %>
                           <% if result.vernacular_author %>
@@ -135,6 +135,15 @@
                           <%= result.publisher %>
                           <% if result.vernacular_publisher %>
                             <span class="vernacular">| <%= result.vernacular_publisher %></span>
+                          <% end %>
+                        </dd>
+                      <% end %>
+                      <% if result.series %>
+                        <dt>Series:</dt>
+                        <dd>
+                          <%= result.series %>
+                          <% if result.vernacular_series %>
+                            <span class="vernacular">| <%= result.vernacular_series %></span>
                           <% end %>
                         </dd>
                       <% end %>


### PR DESCRIPTION
# Overview
Series and its vernacular equivalent will now be added to the list of data for each browse item.

This pull request resolves/closes/fixes [JIRA-1534](https://tools.lib.umich.edu/jira/browse/JIRA-1534).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
  - Break the new/updated unit tests to make sure they're working properly.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Browse for a call number to see `Series` information show up (e.g. `PQ 1852 .B85 1992`)
