### PR TITLE
[SEARCH-1585] Update Browse's Google Tag Manager scripts to point to `GTM-5KZ8T2S`

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -15,7 +15,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-K92RW5D');
+      })(window, document, 'script', 'dataLayer', 'GTM-5KZ8T2S');
     </script>
     <!-- End Google Tag Manager -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -37,7 +37,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-K92RW5D"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-5KZ8T2S"
         height="0"
         width="0"
         style="display: none; visibility: hidden;"


### PR DESCRIPTION
# Overview
A Google Tag Manager container was made for Browse, but then it was realized that Search was using a different container ID. Browse now points to that container ID.

This pull request closes [SEARCH-1585](https://tools.lib.umich.edu/jira/browse/SEARCH-1585).
