### PR TITLE
Removing `specialCharacterUsed` ARC Toolkit Warning

### DIFF
--- a/css/styles/table.css
+++ b/css/styles/table.css
@@ -194,8 +194,19 @@ table.browse-table {
 
 .browse-table tbody .vernacular {
   color: var(--search-neutral-500);
+  display: block;
 }
 
-.browse-table tbody dl dd:first-of-type .vernacular {
-  display: block;
+.browse-table tbody .vernacular.pipe {
+  display: inline;
+}
+
+.browse-table tbody .vernacular.pipe:before {
+  background: var(--search-neutral-500);
+  content: '';
+  display: inline-block;
+  height: 1em;
+  margin: 0 var(--space-x-small);
+  vertical-align: middle;
+  width: 1px;
 }

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -173,7 +173,7 @@
                         <dd>
                           <%= result.author %>
                           <% if result.vernacular_author %>
-                            <span class="vernacular">| <%= result.vernacular_author %></span>
+                            <span class="vernacular pipe"><%= result.vernacular_author %></span>
                           <% end %>
                         </dd>
                       <% end %>
@@ -182,7 +182,7 @@
                         <dd>
                           <%= result.publisher %>
                           <% if result.vernacular_publisher %>
-                            <span class="vernacular">| <%= result.vernacular_publisher %></span>
+                            <span class="vernacular pipe"><%= result.vernacular_publisher %></span>
                           <% end %>
                         </dd>
                       <% end %>
@@ -191,7 +191,7 @@
                         <dd>
                           <%= result.series %>
                           <% if result.vernacular_series %>
-                            <span class="vernacular">| <%= result.vernacular_series %></span>
+                            <span class="vernacular pipe"><%= result.vernacular_series %></span>
                           <% end %>
                         </dd>
                       <% end %>


### PR DESCRIPTION
# Overview
Using pipes (`|`) as a separator for the vernacular information gave a `specialCharacterUsed` warning in ARC Toolkit. In order to remove it, the character has been replaced with a custom `:before` element based on the `.vernacular.pipe` class.

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
