### PR TITLE
[SEARCH-1697] Add "series statement" Solr field to call number browse display after Published field

### DIFF
--- a/lib/models/browse_item.rb
+++ b/lib/models/browse_item.rb
@@ -37,10 +37,10 @@ class BrowseItem
     @catalog_doc["publisher_display"]&.slice(1)
   end
   def series
-    @catalog_doc["series"]&.first
+    @catalog_doc["series_statement"]&.first
   end
   def vernacular_series
-    @catalog_doc["series"]&.slice(1)
+    @catalog_doc["series_statement"]&.slice(1)
   end
   
 

--- a/spec/fixtures/zhizn_bib.json
+++ b/spec/fixtures/zhizn_bib.json
@@ -60,6 +60,8 @@
           "Загадки и тайны судьбы."],
         "series2":["Zagadki i taĭni sudʹby",
           "Загадки и тайни судьбы"],
+        "series_statement":["Zagadki i taĭny sudʹby",
+          "Загадки и тайны судьбы."],
         "era":["17th century"],
         "countryOfPubStr":["Russia (Federation)"],
         "place_of_publication":["Russia (Federation)"],


### PR DESCRIPTION
# Overview
The Solr field displaying `Series` information has changed from `series` to `series_statement`. This pull request updates the information and related tests.

This pull request closes [SEARCH-1697](https://tools.lib.umich.edu/jira/browse/SEARCH-1697).

## Testing
- Run the tests to make sure they pass (`docker-compose run web bundle exec rspec`).
  - Break the new/updated unit tests to make sure they're working properly.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge
- Browse for an item that has `Series`, and see if it displays. (e.g. [PQ 1852 .B85 1992](http://localhost:4567/callnumber?query=PQ+1852+.B85+1992))
