### PR TITLE
[LIBSEARCH-192] Updates to "Technical Overview" page

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -105,7 +105,7 @@
                 <a href="https://lib.umich.edu/research-and-scholarship/help-research/how-we-can-help">Get research help</a>
               </li>
               <li>
-                <a href="https://search.lib.umich.edu/technical-overview">Technical overview</a>
+                <a href="https://search.lib.umich.edu/about-library-search">About Library Search</a>
               </li>
               <li>
                 <a href="https://ill.lib.umich.edu/">Make an <abbr title="Inter Library Loan">I.L.L.</abbr> Request</a>


### PR DESCRIPTION
# Overview
`Technical Overview` has been replaced by `About Library Search`.

This pull request closes [LIBSEARCH-192](https://mlit.atlassian.net/browse/LIBSEARCH-192).

_This cannot be merged until [the change](https://github.com/mlibrary/search/pull/335) is in production._