### PR TITLE
[LIBSEARCH-728] Add Google Analytics 4 with GTM Tracking Code to U-M Library Search

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -19,12 +19,12 @@
     </script>
     <!-- End Google Tag Manager -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-1341620-18"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-W0C2LGTEDC"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'UA-1341620-18');
+      gtag('config', 'G-W0C2LGTEDC');
     </script>
     <title>Library Search | Browse by Call Number (Library of Congress and Dewey)</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -19,6 +19,14 @@
     </script>
     <!-- End Google Tag Manager -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-1341620-18"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-1341620-18');
+    </script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-W0C2LGTEDC"></script>
     <script>
       window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
# Overview
This PR addresses [LIBSEARCH-728](https://mlit.atlassian.net/browse/LIBSEARCH-728).

Google will be retiring Universal Analytics in 2023, forcing users to switch to Google Analytics 4. This pull request adds the script in parallel with the current one for applying and testing. When the GA4 version is officially set up, the UA script will be removed.