### PR TITLE
[LIBSEARCH-711] Remove "Academic Discipline" from Catalog Search drop-down menus

### DIFF
--- a/config/search_dropdown.yml
+++ b/config/search_dropdown.yml
@@ -14,9 +14,6 @@
   - :label: Journal/Serial Title
     :value: journal_title
     :tip: Search the title of a journal or serial publication (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers).
-  - :label: Academic Discipline
-    :value: academic_discipline
-    :tip: Search academic disciplines. <a href="https://search.lib.umich.edu/databases/browse?query=sculpture">Browse all Databases</a> alphabetically or by academic discipline (e.g. International business; Latin american and caribbean studies).
   - :label: Call Number starts with
     :value: call_number_starts_with
     :tip: Search the first few letters and numbers of a call number (e.g. RC662.4 .H38 2016; QH 105). <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers<span class="visually-hidden"> (link points to external site)</span></a>.


### PR DESCRIPTION
# Overview
> "Academic Discipline" option in the Catalog Search field menu is also a filter. This redundancy is not useful and is rarely used.

This pull request closes [LIBSEARCH-711](https://mlit.atlassian.net/browse/LIBSEARCH-711).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Use the dropdown menu and see if `Academic Discipline` does not show.
