### PR TITLE
Bug: Removing `css` Service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,6 @@ services:
       - .env
       - .env-dev-values
 
-  css:
-    build: .
-    volumes:
-      - .:/app
-    environment:
-      - SHELL=/bin/bash
-    command: "npm run watch"
-
 
 volumes:
   gem_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,5 @@ services:
       - .env
       - .env-dev-values
 
-
 volumes:
   gem_cache:


### PR DESCRIPTION
# Overview
On `docker-compose up`, it produced the message:
```bash
css_1  | npm ERR! Missing script: "watch"
```

This is because under the `css` service, `npm run watch` was being called. The script was removed after the `chokidar-cli` package was [uninstalled](https://github.com/mlibrary/catalog-browse/commit/ec6e5b67a14390f60cf99cc5020aad42fa02c079). Since `web` contains the same data, the `css` service has been removed.

## Testing
- Rebuild and run Docker.
  - Does it still launch?
  - Can you still make CSS updates?