### PR TITLE
Design system cleanup

### DIFF
--- a/css/styles/anchors.css
+++ b/css/styles/anchors.css
@@ -26,7 +26,7 @@ a {
 
 a:hover,
 a:focus {
-  text-decoration-thickness: var(--space-xxx-small);
+  text-decoration-thickness: 0.125rem;
 }
 
 

--- a/css/styles/base.css
+++ b/css/styles/base.css
@@ -70,8 +70,8 @@ body {
 
 main {
   flex-grow: 1;
-  margin-bottom: var(--space-xx-large);
-  margin-top: var(--space-xx-large);
+  margin-bottom: 2.5rem;
+  margin-top: 2.5rem;
 }
 
 main > *:first-child {

--- a/css/styles/datastores-navigation.css
+++ b/css/styles/datastores-navigation.css
@@ -20,7 +20,7 @@
 
 .datastores-nav,
 .datastores-nav ol li a {
-  border-bottom: solid var(--space-xxx-small) var(--search-neutral-200);
+  border-bottom: solid 0.125rem var(--search-neutral-200);
 }
   
 .datastores-nav {
@@ -38,8 +38,8 @@
   flex-direction: column;
   justify-content: center;
   list-style: none;
-  margin: 0 calc(var(--space-medium) * -1);
-  margin-bottom: calc(var(--space-xxx-small) * -1);
+  margin: 0 -1rem;
+  margin-bottom: -0.125rem;
   padding: 0;
 }
 
@@ -53,7 +53,7 @@
 
 .datastores-nav ol li a {
   display: block;
-  padding: var(--space-small) var(--space-medium);
+  padding: 0.75rem 1rem;
   position: relative;
 }
 
@@ -77,12 +77,12 @@
   left: 0;
   position: absolute;
   top: 0;
-  width: var(--space-xxx-small);
+  width: 0.125rem;
 }
 
 @media only screen and (min-width: 720px) {
   .datastores-nav ol li a[aria-current=page]:before {
-    height: var(--space-xxx-small);
+    height: 0.125rem;
     top: 100%;
     width: 100%;
   }

--- a/css/styles/m-website-header.css
+++ b/css/styles/m-website-header.css
@@ -20,7 +20,7 @@
 
 m-website-header .website-header-inner-container {
   background-color: var(--color-blue-400);
-  margin: 0 calc(-1 * var(--space-small));
+  margin: 0 -0.75rem;
 }
 
 
@@ -33,10 +33,10 @@ m-website-header a {
   color: white;
   display: inline-block;
   text-decoration: none;
-  padding: var(--space-xx-small) var(--space-small);
+  padding: 0.25rem 0.75rem;
 }
 
 m-website-header a:hover {
   text-decoration: underline;
-  text-underline-offset: var(--space-xxx-small);
+  text-underline-offset: 0.125rem;
 }

--- a/css/styles/pagination.css
+++ b/css/styles/pagination.css
@@ -50,7 +50,6 @@ nav.pagination ul li + li:before {
 
 nav.pagination a {
   align-items: center;
-  display: flex;
   min-height: 3rem;
   min-width: 3rem;
 }
@@ -61,7 +60,6 @@ nav.pagination a {
 /*** 3.0 - Icons ***/
 /*******************/
 
-nav.pagination m-icon svg {
-  position: relative;
-  top: 0.125rem;
+nav.pagination span[class^="material-symbols"] {
+  font-size: 1.5em;
 }

--- a/css/styles/pagination.css
+++ b/css/styles/pagination.css
@@ -25,8 +25,8 @@ nav.pagination ul {
 }
 
 nav.pagination ul li + li {
-  margin-left: var(--space-small);
-  padding-left: var(--space-small);
+  margin-left: 0.75rem;
+  padding-left: 0.75rem;
   position: relative;
 }
 
@@ -51,8 +51,8 @@ nav.pagination ul li + li:before {
 nav.pagination a {
   align-items: center;
   display: flex;
-  min-height: var(--space-xxx-large);
-  min-width: var(--space-xxx-large);
+  min-height: 3rem;
+  min-width: 3rem;
 }
 
 
@@ -63,5 +63,5 @@ nav.pagination a {
 
 nav.pagination m-icon svg {
   position: relative;
-  top: var(--space-xxx-small);
+  top: 0.125rem;
 }

--- a/css/styles/search-box.css
+++ b/css/styles/search-box.css
@@ -15,6 +15,7 @@
  *     2.3.1 - Message
  *   2.4 - Button
  * 3.0 - Tip
+ * 4.0 - Icons
  */
 
 
@@ -95,6 +96,7 @@
 
 .search-box select {
   background: var(--search-neutral-100);
+  height: 100%;
   padding-right: 2.5rem;
   width: 100%;
 }
@@ -107,11 +109,11 @@
 }
 
 .search-box .search-box-dropdown span[class^="material-symbols"] {
-  font-size: 1.5rem;
   pointer-events: none;
   position: absolute;
   right: 0.5rem;
-  top: 0.25rem;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 @media only screen and (min-width: 720px) {
@@ -185,4 +187,14 @@
 
 .search-box .search-tip > * {
   margin: 0;
+}
+
+
+/*******************/
+/*** 4.0 - Icons ***/
+/*******************/
+
+.search-box :is(.search-box-dropdown, button) span[class^="material-symbols"] {
+  font-size: 1.5rem;
+  line-height: 1;
 }

--- a/css/styles/search-box.css
+++ b/css/styles/search-box.css
@@ -26,8 +26,8 @@
 
 .search-box {
   background: var(--search-blue-200);
-  border-bottom: solid var(--space-xxx-small) var(--search-blue-300);
-  padding: var(--space-xx-small) 0 var(--space-medium) 0;
+  border-bottom: solid 0.125rem var(--search-blue-300);
+  padding: 0.25rem 0 1rem 0;
 }
 
 
@@ -58,7 +58,7 @@
 /*** 2.1 - Elements ***/
 
 .search-box .search-form > * {
-  margin-top: var(--space-small);
+  margin-top: 0.75rem;
 }
 
 .search-box select,
@@ -68,7 +68,7 @@
   all: unset;
   box-sizing: border-box;
   line-height: 1.6 !important;
-  padding: var(--space-x-small) var(--space-small);
+  padding: 0.5rem 0.75rem;
 }
 
 .search-box select:focus,
@@ -96,7 +96,7 @@
 
 .search-box select {
   background: var(--search-neutral-100);
-  padding-right: var(--space-xx-large);
+  padding-right: 2.5rem;
   width: 100%;
 }
 
@@ -163,7 +163,7 @@
   cursor: pointer;
   grid-area: button;
   font-weight: 600;
-  margin-left: var(--space-small);
+  margin-left: 0.75rem;
 }
 
 .search-box button:active {
@@ -179,8 +179,8 @@
 
 .search-box .search-tip {
   display: flex;
-  gap: var(--space-small);
-  padding-top: var(--space-small);
+  gap: 0.75rem;
+  padding-top: 0.75rem;
 }
 
 .search-box .search-tip > * {
@@ -190,6 +190,6 @@
 /*** 3.1 - Icon ***/
 
 .search-box .search-tip m-icon svg {
-  margin-top: var(--space-xx-small);
-  width: var(--space-medium);
+  margin-top: 0.25rem;
+  width: 1rem;
 }

--- a/css/styles/search-box.css
+++ b/css/styles/search-box.css
@@ -15,7 +15,6 @@
  *     2.3.1 - Message
  *   2.4 - Button
  * 3.0 - Tip
- *   3.1 - Icon
  */
 
 
@@ -107,11 +106,12 @@
   }
 }
 
-.search-box .search-box-dropdown m-icon {
+.search-box .search-box-dropdown span[class^="material-symbols"] {
+  font-size: 1.5rem;
+  pointer-events: none;
   position: absolute;
   right: 0.5rem;
-  top: 0.6rem;
-  pointer-events: none;
+  top: 0.25rem;
 }
 
 @media only screen and (min-width: 720px) {
@@ -185,11 +185,4 @@
 
 .search-box .search-tip > * {
   margin: 0;
-}
-
-/*** 3.1 - Icon ***/
-
-.search-box .search-tip m-icon svg {
-  margin-top: 0.25rem;
-  width: 1rem;
 }

--- a/css/styles/skip-links.css
+++ b/css/styles/skip-links.css
@@ -38,13 +38,13 @@
 /******************/
 
 .site-skip-links ul {
-  margin: var(--space-medium) 0;
+  margin: 1rem 0;
   text-align: center;
   list-style: none;
 }
 
 .site-skip-links ul li + li {
-  margin-top: var(--space-medium);
+  margin-top: 1rem;
 }
 
 
@@ -55,5 +55,5 @@
 
 .site-skip-links a {
   color: white;
-  padding: var(--space-x-small);
+  padding: 0.5rem;
 }

--- a/css/styles/table.css
+++ b/css/styles/table.css
@@ -46,7 +46,7 @@ table.browse-table {
   border-style: solid;
   border-width: 0;
   display: block;
-  padding: var(--space-small) var(--space-medium);
+  padding: 0.75rem 1rem;
 }
 
 @media only screen and (min-width: 720px) {
@@ -75,12 +75,12 @@ table.browse-table {
 }
 
 .browse-table tr:last-child > *:last-child {
-  border-bottom-width: var(--space-xxx-small);
+  border-bottom-width: 0.125rem;
 }
 
 @media only screen and (min-width: 720px) {
   .browse-table tr:last-child > * {
-    border-bottom-width: var(--space-xxx-small);
+    border-bottom-width: 0.125rem;
   }
 }
 
@@ -90,7 +90,7 @@ table.browse-table {
 
 @media only screen and (min-width: 720px) {
   .browse-table tr > * + * {
-    padding-top: var(--space-small);
+    padding-top: 0.75rem;
   }
 }
 
@@ -143,12 +143,12 @@ table.browse-table {
 
 @media only screen and (min-width: 720px) {
   .browse-table tbody tr > * {
-    border-top-width: var(--space-xxx-small);
+    border-top-width: 0.125rem;
   }
 }
 
 .browse-table tbody tr > *:first-of-type {
-  border-top-width: var(--space-xxx-small);
+  border-top-width: 0.125rem;
 }
 
 @media only screen and (min-width: 720px) {
@@ -162,8 +162,8 @@ table.browse-table {
 }
 
 .browse-table tbody tr[class] > * {
-  border-left-width: var(--space-xxx-small);
-  border-right-width: var(--space-xxx-small);
+  border-left-width: 0.125rem;
+  border-right-width: 0.125rem;
 }
 
 .browse-table tbody tr[class^="match-"] > * {
@@ -193,7 +193,7 @@ table.browse-table {
   clear: left;
   float: left;
   font-weight: var(--semibold);
-  margin-right: var(--space-x-small);
+  margin-right: 0.5rem;
 }
 
 .browse-table tbody dl dd {
@@ -201,7 +201,7 @@ table.browse-table {
 }
 
 .browse-table tbody dl dt.visually-hidden:not(:only-of-type) + dd {
-  margin-bottom: var(--space-x-small);
+  margin-bottom: 0.5rem;
 }
 
 /* 3.2.1 - Anchors */
@@ -227,7 +227,7 @@ table.browse-table {
   content: '';
   display: inline-block;
   height: 1em;
-  margin: 0 var(--space-x-small);
+  margin: 0 0.5rem;
   vertical-align: middle;
   width: 1px;
 }

--- a/css/styles/typography.css
+++ b/css/styles/typography.css
@@ -41,5 +41,6 @@ h1 {
 
 span[class^="material-symbols"] {
   font-size: 1em;
+  line-height: 1.5;
   vertical-align: middle;
 }

--- a/css/styles/typography.css
+++ b/css/styles/typography.css
@@ -41,6 +41,6 @@ h1 {
 
 span[class^="material-symbols"] {
   font-size: 1em;
-  line-height: 1.5;
+  line-height: inherit;
   vertical-align: middle;
 }

--- a/views/components/pagination.erb
+++ b/views/components/pagination.erb
@@ -4,7 +4,7 @@
       <% if list.has_previous_list? %>
         <li>
           <a href="<%= list.previous_url %>">
-            <m-icon name="keyboard-arrow-left"></m-icon>
+            <span class="material-symbols-sharp">chevron_left</span>
             Previous page
           </a>
         </li>
@@ -13,7 +13,7 @@
         <li>
           <a href="<%= list.next_url %>">
             Next page
-            <m-icon name="keyboard-arrow-right"></m-icon>
+            <span class="material-symbols-sharp">chevron_right</span>
           </a>
         </li>
       <% end %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -38,7 +38,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <link rel="stylesheet" href="https://unpkg.com/@umich-lib/web@1/umich-lib.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@48,400,0,200">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@48,600,0,200">
     <link rel="stylesheet" href="<%=ENV.fetch('BASE_URL')%>/browse.css">
     <script type="module" src="https://unpkg.com/@umich-lib/web@1/dist/umich-lib/umich-lib.esm.js"></script>
   </head>

--- a/views/layout/search_box.erb
+++ b/views/layout/search_box.erb
@@ -26,7 +26,7 @@
       </span>
     <% end %>
     <button>
-      <m-icon name="search"></m-icon>
+      <span class="material-symbols-sharp">search</span>
       <span class="visually-hidden">Search</span>
     </button>
   </div>

--- a/views/layout/search_box.erb
+++ b/views/layout/search_box.erb
@@ -31,7 +31,7 @@
     </button>
   </div>
   <div class="viewport-container search-tip">
-    <m-icon name="info-outline"></m-icon>
+    <span class="material-symbols-sharp">info</span>
     <% fields.each do |group| %>
       <% group[:options].each do |option| %>
         <p data-option="<%=option[:value]%>" style="display: <%= option[:value] == active_browse_option ? 'initial' : 'none' %>;">

--- a/views/layout/search_box.erb
+++ b/views/layout/search_box.erb
@@ -17,7 +17,7 @@
           </optgroup>
         <% end %>
       </select>
-      <m-icon name="keyboard-arrow-down"></m-icon>
+      <span class="material-symbols-sharp">expand_more</span>
     </div>
     <input aria-label="Browse text" <% if list.error? %>aria-invalid="true" aria-describedby="input-message"<% end %> type="text" autocomplete="on" name="query" value="<%= list.original_reference %>">
     <% if list.error? %>


### PR DESCRIPTION
# Overview
The Design System is deprecating the `m-icon` component and all `space` variables. This pull request replaces all of the components with [Material Icons](https://fonts.google.com/icons), and the variables with the equivalent of `rem` measurements according to the [design tokens](https://design-system.lib.umich.edu/design-tokens/#space).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Compare [development](http://localhost:4567/callnumber?query=PQ+1852+.B85+1992) to [production](https://search.lib.umich.edu/catalog/browse/callnumber?query=PQ+1852+.B85+1992).
  - Do they look the same?
