### PR TITLE
Bug: Separating author and link text

### DIFF
--- a/lib/models/author_item.rb
+++ b/lib/models/author_item.rb
@@ -20,12 +20,10 @@ class AuthorItem
     !!@exact_match
   end
 
-  # for the view
   def author
     @browse_doc["author"]&.strip
   end
 
-  # for the view
   def author_view
     "#{author}#{" (catalog results)" if results_count > 0}"
   end
@@ -78,7 +76,6 @@ class AuthorItemSee
     @author = author&.strip
   end
 
-  # for the view
   def author_view
     "#{@author} (in author list)"
   end

--- a/lib/models/author_item.rb
+++ b/lib/models/author_item.rb
@@ -24,7 +24,7 @@ class AuthorItem
     @browse_doc["author"]&.strip
   end
 
-  def author_view
+  def author_display
     "#{author}#{" (catalog results)" if results_count > 0}"
   end
 
@@ -76,7 +76,7 @@ class AuthorItemSee
     @author = author&.strip
   end
 
-  def author_view
+  def author_display
     "#{@author} (in author list)"
   end
 

--- a/lib/models/author_item.rb
+++ b/lib/models/author_item.rb
@@ -22,7 +22,12 @@ class AuthorItem
 
   # for the view
   def author
-    "#{@browse_doc["author"]&.strip}#{" (catalog results)" if results_count > 0}"
+    @browse_doc["author"]&.strip
+  end
+
+  # for the view
+  def author_view
+    "#{author}#{" (catalog results)" if results_count > 0}"
   end
 
   def url
@@ -70,7 +75,12 @@ end
 class AuthorItemSee
   attr_reader :author
   def initialize(author)
-    @author = author&.strip + " (in author list)"
+    @author = author&.strip
+  end
+
+  # for the view
+  def author_view
+    "#{@author} (in author list)"
   end
 
   def kind

--- a/views/authors.erb
+++ b/views/authors.erb
@@ -22,7 +22,7 @@
                 <dd>
                   <% if result.results_count > 0 %><a href="<%= result.url%>"><% end %>
                     <span <% if result.exact_match? %>class="strong"<% end %>>
-                      <%=result.author_view%>
+                      <%=result.author_display%>
                     </span>
                   <% if result.results_count > 0 %></a><% end %>
                   <% if result.heading_link? %>
@@ -35,7 +35,7 @@
                       <dt>See:</dt>
                     <% end %>
                     <dd>
-                      <a href="<%= cr.url%>"><%=cr.author_view%></a>
+                      <a href="<%= cr.url%>"><%=cr.author_display%></a>
                     </dd>
                   <% end %>
                 <% end %>

--- a/views/authors.erb
+++ b/views/authors.erb
@@ -22,7 +22,7 @@
                 <dd>
                   <% if result.results_count > 0 %><a href="<%= result.url%>"><% end %>
                     <span <% if result.exact_match? %>class="strong"<% end %>>
-                      <%=result.author%>
+                      <%=result.author_view%>
                     </span>
                   <% if result.results_count > 0 %></a><% end %>
                   <% if result.heading_link? %>
@@ -35,7 +35,7 @@
                       <dt>See:</dt>
                     <% end %>
                     <dd>
-                      <a href="<%= cr.url%>"><%=cr.author%></a>
+                      <a href="<%= cr.url%>"><%=cr.author_view%></a>
                     </dd>
                   <% end %>
                 <% end %>


### PR DESCRIPTION
# Overview
`(catalog results)` and `(in author list)` were being queried when you clicked on the link. This pull request separates the link text from the author so only the author itself is queried.

## Testing
List instructions on how to test the pull request. Some examples:

- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Check the links to see if search and browse are looking at the correct queries.