### PR TITLE
Adding `title` variable

### DIFF
--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -29,7 +29,7 @@ if ENV.fetch("AUTHOR_ON") == "true"
       logger.error(e.message)
       list = AuthorList::Error.new(reference_id)
     end
-    erb :authors, locals: {list: list, feedback_url: 'https://umich.qualtrics.com/jfe/form/SV_43jm8oGIRVLEBbo'}
+    erb :authors, locals: {list: list}
   end
 end
 get "/callnumber" do

--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -29,7 +29,7 @@ if ENV.fetch("AUTHOR_ON") == "true"
       logger.error(e.message)
       list = AuthorList::Error.new(reference_id)
     end
-    erb :authors, locals: {list: list, callout: 'author', feedback_url: 'https://umich.qualtrics.com/jfe/form/SV_43jm8oGIRVLEBbo'}
+    erb :authors, locals: {title: 'Browse by Author', list: list, callout: 'author', feedback_url: 'https://umich.qualtrics.com/jfe/form/SV_43jm8oGIRVLEBbo'}
   end
 end
 get "/callnumber" do
@@ -41,7 +41,7 @@ get "/callnumber" do
     logger.error(e.message)
     list = CallnumberList::Error.new(reference_id)
   end
-  erb :call_number, locals: {list: list, callout: 'call number'}
+  erb :call_number, locals: {title: 'Browse by Call Number (Library of Congress and Dewey)', list: list, callout: 'call number'}
 end
 post "/search" do
   redirect SearchDropdown.for(type: params["type"], query: params["query"]).url

--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -29,7 +29,7 @@ if ENV.fetch("AUTHOR_ON") == "true"
       logger.error(e.message)
       list = AuthorList::Error.new(reference_id)
     end
-    erb :authors, locals: {title: 'Browse by Author', list: list, callout: 'author', feedback_url: 'https://umich.qualtrics.com/jfe/form/SV_43jm8oGIRVLEBbo'}
+    erb :authors, locals: {list: list, feedback_url: 'https://umich.qualtrics.com/jfe/form/SV_43jm8oGIRVLEBbo'}
   end
 end
 get "/callnumber" do
@@ -41,7 +41,7 @@ get "/callnumber" do
     logger.error(e.message)
     list = CallnumberList::Error.new(reference_id)
   end
-  erb :call_number, locals: {title: 'Browse by Call Number (Library of Congress and Dewey)', list: list, callout: 'call number'}
+  erb :call_number, locals: {list: list}
 end
 post "/search" do
   redirect SearchDropdown.for(type: params["type"], query: params["query"]).url

--- a/lib/models/author_list.rb
+++ b/lib/models/author_list.rb
@@ -24,6 +24,10 @@ class AuthorList < BrowseListPresenter
     "author"
   end
 
+  def doc_title
+    "Browse by Author"
+  end
+
   def items
     banner_index = nil
     match_notice = OpenStruct.new(author: original_reference.upcase, match_notice?: true)

--- a/lib/models/author_list.rb
+++ b/lib/models/author_list.rb
@@ -16,6 +16,11 @@ class AuthorList < BrowseListPresenter
     @browse_list = browse_list
   end
 
+  def feedback_url
+    # Author Browse specific url
+    "https://umich.qualtrics.com/jfe/form/SV_43jm8oGIRVLEBbo"
+  end
+
   def name
     "author"
   end

--- a/lib/models/browse_list_presenter.rb
+++ b/lib/models/browse_list_presenter.rb
@@ -49,6 +49,14 @@ class BrowseListPresenter
     raise NotImplementedError, "#{self.class} should have implemented..."
   end
 
+  def doc_title
+    raise NotImplementedError, "#{self.class} should have implemented..."
+  end
+
+  def feedback_url
+    "https://umich.qualtrics.com/jfe/form/SV_bCwYIKueEXs8wBf"
+  end
+
   private
 
   def nav_url(params)

--- a/lib/models/callnumber_list.rb
+++ b/lib/models/callnumber_list.rb
@@ -26,6 +26,10 @@ class CallnumberList < BrowseListPresenter
     "callnumber"
   end
 
+  def doc_title
+    "Browse by Call Number (Library of Congress and Dewey)"
+  end
+
   def items
     banner_index = nil
     match_notice = OpenStruct.new(callnumber: original_reference.upcase, match_notice?: true)

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "funding": [
         {
@@ -139,10 +139,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -180,10 +180,16 @@
       ]
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -474,9 +480,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.242.tgz",
-      "integrity": "sha512-nPdgMWtjjWGCtreW/2adkrB2jyHjClo9PtVhR6rW+oxa4E4Wom642Tn+5LslHP3XPL5MCpkn5/UEY60EXylNeQ==",
+      "version": "1.4.255",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.255.tgz",
+      "integrity": "sha512-H+mFNKow6gi2P5Gi2d1Fvd3TUEJlB9CF7zYaIV9T83BE3wP1xZ0mRPbNTm0KUjyd1QiVy7iKXuIcjlDtBQMiAQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -504,9 +510,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -541,9 +547,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -627,9 +633,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "node_modules/has": {
@@ -666,9 +672,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -680,7 +686,7 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -737,40 +743,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
-    "node_modules/lodash.forown": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-4.4.0.tgz",
-      "integrity": "sha1-hRFc8E9z75ZuztUlEdOJPMRmg68=",
-      "dev": true
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "node_modules/lodash.groupby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
-      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
-      "dev": true
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "node_modules/lodash.uniq": {
@@ -894,7 +870,7 @@
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1383,17 +1359,13 @@
       }
     },
     "node_modules/postcss-reporter": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.4.tgz",
-      "integrity": "sha512-jY/fnpGSin7kwJeunXbY35STp5O3VIxSFdjee5JkoPQ+FfGH5JW3N+Xe9oAPcL9UkjWjkK+JC72o8XH4XXKdhw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.5.tgz",
+      "integrity": "sha512-glWg7VZBilooZGOFPhN9msJ3FQs19Hie7l5a/eE6WglzYqVeH3ong3ShFcp9kDWJT1g2Y/wd59cocf9XxBtkWA==",
       "dev": true,
       "dependencies": {
-        "lodash.difference": "^4.5.0",
-        "lodash.forown": "^4.4.0",
-        "lodash.get": "^4.4.2",
-        "lodash.groupby": "^4.6.0",
-        "lodash.sortby": "^4.7.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.0.0",
+        "thenby": "^1.3.4"
       },
       "engines": {
         "node": ">=10"
@@ -1459,7 +1431,7 @@
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
@@ -1488,7 +1460,7 @@
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
@@ -1509,20 +1481,24 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1640,6 +1616,18 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/svgo": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -1660,6 +1648,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/thenby": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+      "dev": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1683,9 +1677,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz",
-      "integrity": "sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
       "dev": true,
       "funding": [
         {
@@ -1750,9 +1744,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-      "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
@@ -1768,9 +1762,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -1857,15 +1851,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "caniuse-api": {
@@ -1887,9 +1881,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -2099,9 +2093,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.242.tgz",
-      "integrity": "sha512-nPdgMWtjjWGCtreW/2adkrB2jyHjClo9PtVhR6rW+oxa4E4Wom642Tn+5LslHP3XPL5MCpkn5/UEY60EXylNeQ==",
+      "version": "1.4.255",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.255.tgz",
+      "integrity": "sha512-H+mFNKow6gi2P5Gi2d1Fvd3TUEJlB9CF7zYaIV9T83BE3wP1xZ0mRPbNTm0KUjyd1QiVy7iKXuIcjlDtBQMiAQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -2123,9 +2117,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2154,9 +2148,9 @@
       }
     },
     "fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
@@ -2212,9 +2206,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "has": {
@@ -2242,9 +2236,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -2253,7 +2247,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -2293,40 +2287,10 @@
       "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true
     },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
-    "lodash.forown": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-4.4.0.tgz",
-      "integrity": "sha1-hRFc8E9z75ZuztUlEdOJPMRmg68=",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "lodash.groupby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
-      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
-      "dev": true
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.uniq": {
@@ -2417,7 +2381,7 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true
     },
     "postcss": {
@@ -2713,17 +2677,13 @@
       }
     },
     "postcss-reporter": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.4.tgz",
-      "integrity": "sha512-jY/fnpGSin7kwJeunXbY35STp5O3VIxSFdjee5JkoPQ+FfGH5JW3N+Xe9oAPcL9UkjWjkK+JC72o8XH4XXKdhw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.5.tgz",
+      "integrity": "sha512-glWg7VZBilooZGOFPhN9msJ3FQs19Hie7l5a/eE6WglzYqVeH3ong3ShFcp9kDWJT1g2Y/wd59cocf9XxBtkWA==",
       "dev": true,
       "requires": {
-        "lodash.difference": "^4.5.0",
-        "lodash.forown": "^4.4.0",
-        "lodash.get": "^4.4.2",
-        "lodash.groupby": "^4.6.0",
-        "lodash.sortby": "^4.7.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.0.0",
+        "thenby": "^1.3.4"
       }
     },
     "postcss-selector-parser": {
@@ -2764,7 +2724,7 @@
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
       "dev": true
     },
     "queue-microtask": {
@@ -2776,7 +2736,7 @@
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "dev": true,
       "requires": {
         "pify": "^2.3.0"
@@ -2794,17 +2754,18 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "reusify": {
@@ -2876,6 +2837,12 @@
         "postcss-selector-parser": "^6.0.4"
       }
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
     "svgo": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -2890,6 +2857,12 @@
         "picocolors": "^1.0.0",
         "stable": "^0.1.8"
       }
+    },
+    "thenby": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -2907,9 +2880,9 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz",
-      "integrity": "sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",
@@ -2946,9 +2919,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-      "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",
@@ -2961,9 +2934,9 @@
       }
     },
     "yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
     }
   }

--- a/spec/models/author_list_spec.rb
+++ b/spec/models/author_list_spec.rb
@@ -8,7 +8,14 @@ describe AuthorList do
 
   context "doc_title" do
     it "returns the document title" do
-      expect(subject.doc_title).to eq("Browse by Author");
+      expect(subject.doc_title).to eq("Browse by Author")
+    end
+  end
+
+  context "feedback_url" do
+    it "has a different url than the default form" do
+      expect(subject.feedback_url.class).to eq(String)
+      expect(subject.feedback_url).not_to eq(BrowseListPresenter.new(browse_list: nil).feedback_url)
     end
   end
 

--- a/spec/models/author_list_spec.rb
+++ b/spec/models/author_list_spec.rb
@@ -1,6 +1,6 @@
-describe CallnumberList do
+describe AuthorList do
   before(:each) do
-    @browse_list = instance_double(BrowseList, original_reference: "callnumber")
+    @browse_list = instance_double(BrowseList, original_reference: "author")
   end
   subject do
     described_class.new(browse_list: @browse_list)
@@ -8,7 +8,7 @@ describe CallnumberList do
 
   context "doc_title" do
     it "returns the document title" do
-      expect(subject.doc_title).to eq("Browse by Call Number (Library of Congress and Dewey)");
+      expect(subject.doc_title).to eq("Browse by Author");
     end
   end
 
@@ -19,7 +19,7 @@ describe CallnumberList do
     end
     it "returns appropriate text for 1 match" do
       allow(@browse_list).to receive(:num_matches).and_return(1)
-      expect(subject.match_text).to include("a matching call number")
+      expect(subject.match_text).to include("a matching author")
     end
     it "returns appropriate text for 2 matches" do
       allow(@browse_list).to receive(:num_matches).and_return(2)
@@ -29,17 +29,17 @@ describe CallnumberList do
   context "#previous_url" do
     it "returns appropriate url" do
       allow(@browse_list).to receive(:previous_url_params).and_return({param_1: "value_1", param_2: "value_2"})
-      expect(subject.previous_url).to eq("#{ENV.fetch("BASE_URL")}/callnumber?param_1=value_1&param_2=value_2")
+      expect(subject.previous_url).to eq("#{ENV.fetch("BASE_URL")}/author?param_1=value_1&param_2=value_2")
     end
   end
   context "#next_url" do
     it "returns appropriate url" do
       allow(@browse_list).to receive(:next_url_params).and_return({param_1: "value_1", param_2: "value_2"})
-      expect(subject.next_url).to eq("#{ENV.fetch("BASE_URL")}/callnumber?param_1=value_1&param_2=value_2")
+      expect(subject.next_url).to eq("#{ENV.fetch("BASE_URL")}/author?param_1=value_1&param_2=value_2")
     end
   end
 end
-describe CallnumberList::Error do
+describe AuthorList::Error do
   before(:each) do
     @params = {
       original_reference: "OSU"
@@ -55,7 +55,7 @@ describe CallnumberList::Error do
   end
   context "#error_message" do
     it "returns an error message" do
-      expect(subject.error_message).to eq("<span class=\"strong\">{:original_reference=>\"OSU\"}</span> is not a valid call number query. Please try a using a valid Library of Congress call number (enter one or two letters and a number) or valid Dewey call number (start with three numbers).")
+      expect(subject.error_message).to eq("<span class=\"strong\">{:original_reference=>\"OSU\"}</span> is not a valid author query.")
     end
   end
 end

--- a/spec/models/browse_list_presenter_spec.rb
+++ b/spec/models/browse_list_presenter_spec.rb
@@ -5,13 +5,9 @@ describe BrowseListPresenter do
   subject do
     described_class.new(browse_list: @browse_list)
   end
-  it "raises an error if the child class hasn't implemented #path" do
-    expect { subject.path }.to raise_error(NotImplementedError)
-  end
-  it "raises an error if the child class hasn't implemented #name" do
-    expect { subject.name }.to raise_error(NotImplementedError)
-  end
-  it "raises an error if the child class hasn't implemented #help_text" do
-    expect { subject.help_text }.to raise_error(NotImplementedError)
+  ["path", "name", "help_text", "doc_title"].each do |method|
+    it "raises an error if the child class hasn't implemented ##{method}" do
+      expect { subject.public_send(method) }.to raise_error(NotImplementedError)
+    end
   end
 end

--- a/spec/models/callnumber_list_spec.rb
+++ b/spec/models/callnumber_list_spec.rb
@@ -8,7 +8,14 @@ describe CallnumberList do
 
   context "doc_title" do
     it "returns the document title" do
-      expect(subject.doc_title).to eq("Browse by Call Number (Library of Congress and Dewey)");
+      expect(subject.doc_title).to eq("Browse by Call Number (Library of Congress and Dewey)")
+    end
+  end
+
+  context "feedback_url" do
+    it "has the default form url" do
+      expect(subject.feedback_url.class).to eq(String)
+      expect(subject.feedback_url).to eq(BrowseListPresenter.new(browse_list: nil).feedback_url)
     end
   end
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -34,7 +34,7 @@
       gtag('js', new Date());
       gtag('config', 'G-W0C2LGTEDC');
     </script>
-    <title>Library Search | <%= title %></title>
+    <title>Library Search | <%= list.doc_title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <link rel="stylesheet" href="https://unpkg.com/@umich-lib/web@1/umich-lib.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">
@@ -80,7 +80,7 @@
         if !url_params.include? 'direction'
       %>
         <m-callout dismissable icon>
-          <p><span class="strong">Browse by <%= callout %> beta:</span> We're testing a new feature to browse the catalog by <%= callout %>. Let us know what you think at our <%= erb :'components/external_link', locals: { url: defined?(feedback_url) ? feedback_url : 'https://umich.qualtrics.com/jfe/form/SV_bCwYIKueEXs8wBf', text: 'feedback form' } %>.</p>
+          <p><span class="strong">Browse by <%= list.name %> beta:</span> We're testing a new feature to browse the catalog by <%= list.name %>. Let us know what you think at our <%= erb :'components/external_link', locals: { url: defined?(feedback_url) ? feedback_url : 'https://umich.qualtrics.com/jfe/form/SV_bCwYIKueEXs8wBf', text: 'feedback form' } %>.</p>
         </m-callout>
       <% end %>
       <h1 id="maincontent" tabindex="-1">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -34,7 +34,7 @@
       gtag('js', new Date());
       gtag('config', 'G-W0C2LGTEDC');
     </script>
-    <title>Library Search | Browse by Call Number (Library of Congress and Dewey)</title>
+    <title>Library Search | <%= title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <link rel="stylesheet" href="https://unpkg.com/@umich-lib/web@1/umich-lib.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -80,7 +80,7 @@
         if !url_params.include? 'direction'
       %>
         <m-callout dismissable icon>
-          <p><span class="strong">Browse by <%= list.name %> beta:</span> We're testing a new feature to browse the catalog by <%= list.name %>. Let us know what you think at our <%= erb :'components/external_link', locals: { url: defined?(feedback_url) ? feedback_url : 'https://umich.qualtrics.com/jfe/form/SV_bCwYIKueEXs8wBf', text: 'feedback form' } %>.</p>
+          <p><span class="strong">Browse by <%= list.name %> beta:</span> We're testing a new feature to browse the catalog by <%= list.name %>. Let us know what you think at our <%= erb :'components/external_link', locals: { url: list.feedback_url, text: 'feedback form' } %>.</p>
         </m-callout>
       <% end %>
       <h1 id="maincontent" tabindex="-1">


### PR DESCRIPTION
# Overview
According to [Browse Punchlist -- Feedback, Bugs, Suggestions, etc.](https://docs.google.com/spreadsheets/d/1r2G8XfJwrGMOL4hKoV-_O7fPv17SIKHzdzAT4bZamEg/edit?usp=sharing):

> Page title(s) in Author Browse are "Search | Browse by Call Number (Library of Congress and Dewey)" when they should be "Search | Browse by Author"

This pull request creates a `title` local variable that allows the `<title>` to be set for each view.

- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Browse by call number.
  - Does the title read `Library Search | Browse by Call Number (Library of Congress and Dewey)`?
- Browse by author.
  - Does the title read `Library Search | Browse by Author`?
