### PR TITLE
[LIBSEARCH-776] Remove (catalog results) from Main author links in Author browse

### DIFF
--- a/lib/models/author_item.rb
+++ b/lib/models/author_item.rb
@@ -24,10 +24,6 @@ class AuthorItem
     @browse_doc["author"]&.strip
   end
 
-  def author_display
-    "#{author}#{" (catalog results)" if results_count > 0}"
-  end
-
   def url
     params = {library: "U-M Ann Arbor Libraries", query: "author:(\"#{author}\")"}
     "https://search.lib.umich.edu/catalog?#{URI.encode_www_form(params)}"

--- a/views/authors.erb
+++ b/views/authors.erb
@@ -22,7 +22,7 @@
                 <dd>
                   <% if result.results_count > 0 %><a href="<%= result.url%>"><% end %>
                     <span <% if result.exact_match? %>class="strong"<% end %>>
-                      <%=result.author_display%>
+                      <%=result.author%>
                     </span>
                   <% if result.results_count > 0 %></a><% end %>
                   <% if result.heading_link? %>


### PR DESCRIPTION
# Overview
Removing ` (catalog results)` from the link label has shown to improve readability, according to UX research.

This pull request resolves [LIBSEARCH-776](https://mlit.atlassian.net/browse/LIBSEARCH-776).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Browse an [author](http://localhost:4567/author?query=Twain%2C+Mark)
  - Does ` (catalog results)` show in the main author link?
  - Do you still see ` (in author list)` in cross references?
