### PR TITLE
[LIBSEARCH-777] Update "Browse by author help" text in Author browse index views

### DIFF
--- a/lib/models/author_list.rb
+++ b/lib/models/author_list.rb
@@ -37,7 +37,7 @@ class AuthorList < BrowseListPresenter
   end
 
   def help_text
-    '<span class="strong">Browse by author help:</span> Search an author (last name, first name) and view an alphabetical list of all authors headings (personal names and corporate names) and variations of those names indexed in the Library catalog.'
+    '<span class="strong">Browse by author help:</span> Search an author (last names, first name), organization or conference and view an alphabetical list of all author headings that link to matching records in the library catalog. Also view variations of some author names (pseudonyms) linked to that part of the author index.'
   end
 end
 


### PR DESCRIPTION
# Overview
The Author Browse help text has been updated to improve clarity, based on UX research.

This pull request resolves [LIBSEARCH-777](https://mlit.atlassian.net/browse/LIBSEARCH-777).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Browse an [author](http://localhost:4567/author?query=Twain%2C+Mark)
  - Under the `Browse [author] in authors` title, does it say:
  ```
  Browse by author help: Search an author (last names, first name), organization or conference and view an alphabetical list of all author headings that link to matching records in the library catalog. Also view variations of some author names (pseudonyms) linked to that part of the author index.
  ```
