### PR TITLE
[LIBSEARCH-779] Update h1 Label in Catalog Browse: Browse by Author views. 

### DIFF
--- a/lib/models/browse_list_presenter.rb
+++ b/lib/models/browse_list_presenter.rb
@@ -8,7 +8,11 @@ class BrowseListPresenter
 
   def title
     if show_table?
-      "Browse &ldquo;#{original_reference}&rdquo; in #{name}s"
+      if name == "author"
+        "Browse &ldquo;#{original_reference}&rdquo; in an alphabetical list of #{name}s"
+      else
+        "Browse &ldquo;#{original_reference}&rdquo; in #{name}s"
+      end
     else
       "Browse by #{name}"
     end


### PR DESCRIPTION
# Overview
Replacing `Browse “Author name” in authors` with `Browse “Author name” in an alphabetical list of authors` when browing in `author`.

This pull request closes [LIBSEARCH-779](https://mlit.atlassian.net/browse/LIBSEARCH-779).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- [Browse by author](http://localhost:4567/author?query=Twain%2C+Mark)
  - Does it say `Browse “Author name” in an alphabetical list of authors`?
- [Browse by callnumber](http://localhost:4567/callnumber?query=UM1)
  - Does it say `Browse “Call number” in call numbers`?
