### PR TITLE
[DS-120] Update properties to jsDelivr

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -36,11 +36,11 @@
     </script>
     <title>Library Search | <%= list.doc_title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-    <link rel="stylesheet" href="https://unpkg.com/@umich-lib/web@1/umich-lib.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/umich-lib.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@48,600,0,0..200">
     <link rel="stylesheet" href="<%=ENV.fetch('BASE_URL')%>/browse.css">
-    <script type="module" src="https://unpkg.com/@umich-lib/web@1/dist/umich-lib/umich-lib.esm.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/dist/umich-lib/umich-lib.esm.js"></script>
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
# Overview
Design System was using `unpkg` for their CDN, but has since been unsupported. They are now switching to `jsDelivr`.

This pull request updates the new CDN.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check the website and see if anything looks broken.
