### PR TITLE
adds logic to turn off browse by author

### DIFF
--- a/views/layout/search_box.erb
+++ b/views/layout/search_box.erb
@@ -1,6 +1,12 @@
 <%
   fields = YAML.load_file("./config/search_dropdown.yml")
   active_browse_option = 'browse_by_' + request.path_info[1..-1]
+  if ENV.fetch("AUTHOR_ON") == "false"
+    browse_by = fields.find{|x| x[:label] == "Browse by [BETA]"}
+    browse_by_author = browse_by[:options].find{|x| x[:label] == "Browse by author"}
+    browse_by_author[:label] = "Browse by author (coming soon)"
+    browse_by_author[:disabled] = "disabled"
+  end
 %>
 
 <form class="search-box" role="search" method="post" action="<%= ENV.fetch('BASE_URL') %>/search">


### PR DESCRIPTION
# Overview
Fixes a bug where the drop down shows "Browse by Author" as an option even though it's not available yet. 

This PR turns it off if `AUTHOR_ON == "false"`
