### PR TITLE
removes browse by title as coming soon

### DIFF
--- a/config/search_dropdown.yml
+++ b/config/search_dropdown.yml
@@ -39,7 +39,3 @@
     :value: browse_by_subject
     :tip: Browse an A-Z list of subjects (e.g. motion pictures; history--United States; Eliot, George).
     :disabled: disabled
-  - :label: Browse by title (coming soon)
-    :value: browse_by_title
-    :tip: Browse an alphabetical list of titles for books, online journals, serials, media, etc. (e.g. Nine stories; Tom Swift).
-    :disabled: disabled


### PR DESCRIPTION
# Overview
Takes out "Browse by title" as a coming soon disabled option in the dropdown.
