### PR TITLE
Clean up the user-submitted author browse string

### DIFF
--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -19,10 +19,17 @@ CatalogSolrClient.configure do |config|
   config.solr_url = ENV.fetch("BIBLIO_SOLR")
 end
 
+# Remove extraneous (and potentially damaging) stuff from the author string
+# TODO: add bits to remove field prefix (e.g., 'author:') as defined in 00-catalog.yml
+def cleanup_author_browse_string(str)
+  str.gsub(/\p{P}\p{Sm}\p{Sc}\p{So}/, "")
+end
+
 if ENV.fetch("AUTHOR_ON") == "true"
   get "/author" do
     author = params[:query]
-    reference_id = params[:reference_id] || author
+    query_string = cleanup_author_browse_string(author)
+    reference_id = params[:reference_id] || query_string
     begin
       list = AuthorList.for(direction: params[:direction], reference_id: reference_id, num_rows_to_display: 20, original_reference: author, banner_reference: params[:banner_reference])
     rescue => e

--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -6,6 +6,7 @@ require "yaml"
 
 require_relative "lib/catalog_solr_client"
 require_relative "lib/utilities/browse_solr_client"
+require_relative "lib/utilities/string_cleaner"
 require_relative "lib/models/browse_list"
 require_relative "lib/models/browse_list_presenter"
 require_relative "lib/models/callnumber_list"
@@ -19,17 +20,10 @@ CatalogSolrClient.configure do |config|
   config.solr_url = ENV.fetch("BIBLIO_SOLR")
 end
 
-# Remove extraneous (and potentially damaging) stuff from the author string
-# TODO: add bits to remove field prefix (e.g., 'author:') as defined in 00-catalog.yml
-def cleanup_author_browse_string(str)
-  str.gsub(/\p{P}\p{Sm}\p{Sc}\p{So}/, "")
-end
-
 if ENV.fetch("AUTHOR_ON") == "true"
   get "/author" do
-    author = params[:query]
-    query_string = cleanup_author_browse_string(author)
-    reference_id = params[:reference_id] || query_string
+    author = StringCleaner.cleanup_author_browse_string(params[:query])
+    reference_id = params[:reference_id] || author
     begin
       list = AuthorList.for(direction: params[:direction], reference_id: reference_id, num_rows_to_display: 20, original_reference: author, banner_reference: params[:banner_reference])
     rescue => e

--- a/lib/utilities/string_cleaner.rb
+++ b/lib/utilities/string_cleaner.rb
@@ -1,4 +1,13 @@
 module StringCleaner
+  def self.prefixes
+    # are there more of these?
+    [
+      "author",
+      "subject",
+      "academic_discipline"
+    ]
+  end
+
   def self.strip_symbols(str)
     str.gsub(/[\p{P}\p{Sm}\p{Sc}\p{So}^`]/, "")
   end
@@ -6,6 +15,12 @@ module StringCleaner
   # TODO: add bits to remove field prefix (e.g., 'author:') as defined in 00-catalog.yml
   # this is where the author browse specific cleaning goes
   def self.cleanup_author_browse_string(str)
+    prefixes.each do |x|
+      if str.match?(/^#{x}:"/)
+        str.sub!(/^#{x}:"/, "")
+        break
+      end
+    end
     strip_symbols(str)
   end
 end

--- a/lib/utilities/string_cleaner.rb
+++ b/lib/utilities/string_cleaner.rb
@@ -1,0 +1,11 @@
+module StringCleaner
+  def self.strip_symbols(str)
+    str.gsub(/[\p{P}\p{Sm}\p{Sc}\p{So}^`]/, "")
+  end
+
+  # TODO: add bits to remove field prefix (e.g., 'author:') as defined in 00-catalog.yml
+  # this is where the author browse specific cleaning goes
+  def self.cleanup_author_browse_string(str)
+    strip_symbols(str)
+  end
+end

--- a/lib/utilities/string_cleaner.rb
+++ b/lib/utilities/string_cleaner.rb
@@ -26,14 +26,14 @@ module StringCleaner
 
   def self.strip_symbols(str)
     # str.gsub(/[\p{P}\p{Sm}\p{Sc}\p{So}^`]/, "")
-    str.gsub(/["'(){}\[\]]/, "")
+    str.gsub(/["']/, "")
   end
 
   # TODO: add bits to remove field prefix (e.g., 'author:') as defined in 00-catalog.yml
   # this is where the author browse specific cleaning goes
   def self.cleanup_author_browse_string(str)
     prefixes.each do |x|
-      if str.match?(/^#{x}:["(]/)
+      if str.match?(/^#{x}:/)
         str.sub!(/^#{x}:/, "")
         break
       end

--- a/lib/utilities/string_cleaner.rb
+++ b/lib/utilities/string_cleaner.rb
@@ -2,22 +2,39 @@ module StringCleaner
   def self.prefixes
     # are there more of these?
     [
+      "academic_discipline",
       "author",
+      "call_number_starts_with",
+      "contains",
+      "contributor",
+      "date",
+      "isbn",
+      "isn",
+      "issn",
+      "journal_title",
+      "keyword",
+      "pmid",
+      "publication_date",
+      "publisher",
+      "realuth",
+      "series",
       "subject",
-      "academic_discipline"
+      "title",
+      "title_starts_with"
     ]
   end
 
   def self.strip_symbols(str)
-    str.gsub(/[\p{P}\p{Sm}\p{Sc}\p{So}^`]/, "")
+    # str.gsub(/[\p{P}\p{Sm}\p{Sc}\p{So}^`]/, "")
+    str.gsub(/["'(){}\[\]]/, "")
   end
 
   # TODO: add bits to remove field prefix (e.g., 'author:') as defined in 00-catalog.yml
   # this is where the author browse specific cleaning goes
   def self.cleanup_author_browse_string(str)
     prefixes.each do |x|
-      if str.match?(/^#{x}:"/)
-        str.sub!(/^#{x}:"/, "")
+      if str.match?(/^#{x}:["(]/)
+        str.sub!(/^#{x}:/, "")
         break
       end
     end

--- a/spec/utilities/string_cleaner_spec.rb
+++ b/spec/utilities/string_cleaner_spec.rb
@@ -24,7 +24,8 @@ describe StringCleaner do
     it "cleans up symbols" do
       expect(described_class.cleanup_author_browse_string("©+$.")).to eq("")
     end
-    xit "removes 'author:' prefix" do
+    it "removes 'author:' prefix" do
+      expect(described_class.cleanup_author_browse_string('author:"Author Name"')).to eq("Author Name")
     end
   end
 end

--- a/spec/utilities/string_cleaner_spec.rb
+++ b/spec/utilities/string_cleaner_spec.rb
@@ -1,31 +1,15 @@
 describe StringCleaner do
   context ".strip_symbols" do
-    it "removes punctuation" do
-      # for \p{P}
-      expect(described_class.strip_symbols('!"#%&\'()*,_./:;=?@[]\\_{}')).to eq("")
-    end
-    it "removes math symbols" do
-      # for \p{Sm}
-      expect(described_class.strip_symbols("+<=>|~≤≥±≠÷×")).to eq("")
-    end
-    it "removes currency symbols" do
-      # for \p{Sc}
-      expect(described_class.strip_symbols("$¢¥£€¤")).to eq("")
-    end
-    it "removes other symbols" do
-      # for \p{So}
-      expect(described_class.strip_symbols("©༕®°")).to eq("")
-    end
-    it "removes a few modifiers" do
-      expect(described_class.strip_symbols("`^")).to eq("")
+    it "removes certain punctuation" do
+      expect(described_class.strip_symbols('"\'(){}[]')).to eq("")
     end
   end
   context ".cleanup_author_browse_string" do
-    it "cleans up symbols" do
-      expect(described_class.cleanup_author_browse_string("©+$.")).to eq("")
-    end
     it "removes 'author:' prefix" do
       expect(described_class.cleanup_author_browse_string('author:"Author Name"')).to eq("Author Name")
+    end
+    it "removes 'isn(' prefix" do
+      expect(described_class.cleanup_author_browse_string('isn:("123-456")')).to eq("123-456")
     end
   end
 end

--- a/spec/utilities/string_cleaner_spec.rb
+++ b/spec/utilities/string_cleaner_spec.rb
@@ -1,7 +1,7 @@
 describe StringCleaner do
   context ".strip_symbols" do
     it "removes certain punctuation" do
-      expect(described_class.strip_symbols('"\'(){}[]')).to eq("")
+      expect(described_class.strip_symbols('"\'')).to eq("")
     end
   end
   context ".cleanup_author_browse_string" do
@@ -9,7 +9,7 @@ describe StringCleaner do
       expect(described_class.cleanup_author_browse_string('author:"Author Name"')).to eq("Author Name")
     end
     it "removes 'isn(' prefix" do
-      expect(described_class.cleanup_author_browse_string('isn:("123-456")')).to eq("123-456")
+      expect(described_class.cleanup_author_browse_string("isn:(123-456)")).to eq("(123-456)")
     end
   end
 end

--- a/spec/utilities/string_cleaner_spec.rb
+++ b/spec/utilities/string_cleaner_spec.rb
@@ -1,0 +1,30 @@
+describe StringCleaner do
+  context ".strip_symbols" do
+    it "removes punctuation" do
+      # for \p{P}
+      expect(described_class.strip_symbols('!"#%&\'()*,_./:;=?@[]\\_{}')).to eq("")
+    end
+    it "removes math symbols" do
+      # for \p{Sm}
+      expect(described_class.strip_symbols("+<=>|~≤≥±≠÷×")).to eq("")
+    end
+    it "removes currency symbols" do
+      # for \p{Sc}
+      expect(described_class.strip_symbols("$¢¥£€¤")).to eq("")
+    end
+    it "removes other symbols" do
+      # for \p{So}
+      expect(described_class.strip_symbols("©༕®°")).to eq("")
+    end
+    it "removes a few modifiers" do
+      expect(described_class.strip_symbols("`^")).to eq("")
+    end
+  end
+  context ".cleanup_author_browse_string" do
+    it "cleans up symbols" do
+      expect(described_class.cleanup_author_browse_string("©+$.")).to eq("")
+    end
+    xit "removes 'author:' prefix" do
+    end
+  end
+end


### PR DESCRIPTION
This removes unnecessary (to browse) characters from the user-submitted author string before setting the `reference_id` which is then sent to `AuthorList.for`.

I'm not at all sure how to test this. Would love to be taught.


