### PR TITLE
fix: Replacing `Use instead of` with `Broader Term(s)`

### DIFF
--- a/views/subject.erb
+++ b/views/subject.erb
@@ -36,7 +36,7 @@
                         <%=
                           case cr
                           when :broader
-                            "Use instead of:"
+                            "Broader Term(s):"
                           when :narrower
                             "Narrower Term(s):"
                           else


### PR DESCRIPTION
# Overview
The label `Use instead of` is confusing for broader term results. Changing it to `Broader Term(s)` aligns with the `Narrower Term(s)` label, and is more straightforward.