### PR TITLE
2023-03-23 Meeting

### DIFF
--- a/lib/models/author_item.rb
+++ b/lib/models/author_item.rb
@@ -77,7 +77,7 @@ class AuthorItemSeeAlso
   end
 
   def record_text
-    "#{count} record#{"s" if count != 1}"
+    "#{count} record#{"s" if count != '1'}"
   end
 
   def kind

--- a/lib/models/author_item.rb
+++ b/lib/models/author_item.rb
@@ -77,7 +77,7 @@ class AuthorItemSeeAlso
   end
 
   def record_text
-    "#{count} record#{"s" if count != '1'}"
+    "#{count} record#{"s" if count != "1"}"
   end
 
   def kind

--- a/lib/models/browse_list_presenter.rb
+++ b/lib/models/browse_list_presenter.rb
@@ -8,10 +8,10 @@ class BrowseListPresenter
 
   def title
     if show_table?
-      if name == "author"
-        "Browse &ldquo;#{original_reference}&rdquo; in an alphabetical list of #{name}s"
-      else
+      if name == "call number"
         "Browse &ldquo;#{original_reference}&rdquo; in #{name}s"
+      else
+        "Browse &ldquo;#{original_reference}&rdquo; in an alphabetical list of #{name}s"
       end
     else
       "Browse by #{name}"

--- a/lib/models/subject_item.rb
+++ b/lib/models/subject_item.rb
@@ -85,7 +85,7 @@ class SubjectItemCrossReference
   end
 
   def record_text
-    "#{count} record#{"s" if count != '1'}"
+    "#{count} record#{"s" if count != "1"}"
   end
 
   def url

--- a/lib/models/subject_item.rb
+++ b/lib/models/subject_item.rb
@@ -85,7 +85,7 @@ class SubjectItemCrossReference
   end
 
   def record_text
-    "#{count} record#{"s" if count != 1}"
+    "#{count} record#{"s" if count != '1'}"
   end
 
   def url


### PR DESCRIPTION
# Overview
> Update h1 to be: Browse [search term] in alphabetical list of subjects

This title now applies to all browse options that are not `call number`.

> Can we make “records” singular for 1-record entries?

The logic was there, but was being compared to the incorrect type. `count` returns a string, and being compared to a number. The number has been converted to a string.

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- See if `1 record` will show up for a [cross reference](http://localhost:4567/subject?query=Peatland+management).
- See if [subject browse] now says `Browse “[term]” in an alphabetical list of subjects`.