### PR TITLE
[LIBSEARCH-872] Add "remediation of harmful subjects" language to subject browse pages

### DIFF
--- a/css/styles/m-callout.css
+++ b/css/styles/m-callout.css
@@ -16,7 +16,7 @@
 /*** 1.0 - Container ***/
 /***********************/
 
-m-callout {
+m-callout:first-child {
   margin: 0;
 }
 

--- a/views/components/harmful_language_statement.erb
+++ b/views/components/harmful_language_statement.erb
@@ -1,0 +1,5 @@
+<% if request.path_info.include? view %>
+  <m-callout subtle icon>
+    <p>The University of Michigan Library aims to describe library materials in a way that respects the people and communities who create, use, and are represented in our collections. Report harmful or offensive language anonymously through our <a href="https://docs.google.com/forms/d/e/1FAIpQLSfSJ7y-zqmbNQ6ssAhSmwB7vF-NyZR9nVwBICFI8dY5aP1-TA/viewform">metadata feedback form</a>. More information at <a href="https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata">Remediation of Harmful Language</a>.</p>
+  </m-callout>
+<% end %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -92,6 +92,7 @@
       <%= erb :'components/pagination', locals: { label: 'Top pagination', list: list } %>
       <%= yield %>
       <%= erb :'components/pagination', locals: { label: 'Bottom pagination', list: list } %>
+      <%= erb :'components/harmful_language_statement', locals: { view: 'subject' } %>
       <section class="give-feedback">
         <%= erb :'components/external_link', locals: { url: 'https://umich.qualtrics.com/jfe/form/SV_bCwYIKueEXs8wBf', text: 'Give feedback about this page' } %>
       </section>


### PR DESCRIPTION
# Overview
This pull request adds an `m-callout` component that contains a statement about remediating harmful language. It will only show in Subject browse.

This pull request closes [LIBSEARCH-872](https://mlit.atlassian.net/browse/LIBSEARCH-872).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Build and run the site. Check and see if the statement only shows in Subject browse. Does it also show while navigating through the pagination?
