### PR TITLE
[LIBSEARCH-876] Update display of long subject lists in Subject Browse

### DIFF
--- a/css/styles/cross-references.css
+++ b/css/styles/cross-references.css
@@ -21,7 +21,7 @@
 ol.cross-references-list {
   color: var(--search-neutral-500);
   list-style: none;
-  margin: 0;
+  margin: 0 0 0 1rem;
   padding: 0;
 }
 

--- a/css/styles/table.css
+++ b/css/styles/table.css
@@ -194,3 +194,23 @@ table.browse-table {
   display: inline-block;
   font-weight: var(--semibold);
 }
+
+/* 3.2.2 - Records */
+
+.browse-table.subject-browse tbody td.column-main .record-text {
+  display: block;
+}
+
+.browse-table.subject-browse tbody td.column-records {
+  display: none;
+}
+
+@media only screen and (min-width: 720px) {
+  .browse-table.subject-browse tbody td.column-main .record-text {
+    display: none;
+  }
+
+  .browse-table.subject-browse tbody td.column-records {
+    display: table-cell;
+  }
+}

--- a/views/subject.erb
+++ b/views/subject.erb
@@ -28,6 +28,9 @@
                   <% if result.heading_link? %>
                     <%= erb :'components/external_link', locals: { url: result.heading_link, text: 'About this subject', classes: 'vernacular pipe' } %>
                   <% end %>
+                  <span class="record-text">
+                    <%= result.record_text %>
+                  </span>
                 </dd>
                 <% if result.has_cross_references? %>
                   <% result.cross_references.to_h.keys.each do | cr | %>
@@ -75,7 +78,7 @@
                 <% end %>
               </dl>
             </td>
-            <td>
+            <td class="column-records">
               <%= result.record_text %>
             </td>
           </tr>


### PR DESCRIPTION
# Overview
There were two UI-related issues that need improvement:
1. Terms are found to be difficult to distinguish between the bolded headings. To fix this, the list of cross references has been indented.
2. On mobile, the total number of records for a subject entry moves to the bottom of the display and can be hidden if there are a lot of cross references. The number of records now appear under the subject on mobile.

This pull request resolves [LIBSEARCH-876](https://mlit.atlassian.net/browse/LIBSEARCH-876).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Build the styles and run the site.
  - Do the records appear directly under the subject on mobile?
  - Are the list of cross references indented?
