### PR TITLE
[LIBSEARCH-888] Update Google Tag Manager Tracking Code in Catalog Browse views

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -26,7 +26,7 @@
         j.async = true;
         j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-5KZ8T2S');
+      })(window, document, 'script', 'dataLayer', 'GTM-TX44PM3');
     </script>
     <!-- End Google Tag Manager -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -50,7 +50,7 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
       <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-5KZ8T2S"
+        src="https://www.googletagmanager.com/ns.html?id=GTM-TX44PM3"
         height="0"
         width="0"
         style="display: none; visibility: hidden;"


### PR DESCRIPTION
# Overview
> We migrated to a new GTM Container and we need to update the tracking code for Catalog browse (it’s not collecting data because it has the old tracking code and GTM tracking ID.
