### PR TITLE
fix: callnumber browse items without a catlog record

### DIFF
--- a/lib/models/callnumber_item.rb
+++ b/lib/models/callnumber_item.rb
@@ -1,7 +1,7 @@
 class CallnumberItem
   def initialize(browse_doc:, catalog_doc:, exact_match:)
     @browse_doc = browse_doc
-    @catalog_doc = catalog_doc
+    @catalog_doc = catalog_doc || {}
     @exact_match = exact_match
   end
 

--- a/spec/models/callnumber_item_spec.rb
+++ b/spec/models/callnumber_item_spec.rb
@@ -25,6 +25,10 @@ describe CallnumberItem do
       @catalog_doc["edition"] = ["my edition", "vernacular edition"]
       expect(subject.title).to eq("Zhiznʹ gospodina de Molʹera / M. Bulgakov ; [podgot. teksta i poslesl. V.I. Loseva]. my edition")
     end
+    it "is an empty string when there is no matching catalog record" do
+      @catalog_doc = nil
+      expect(subject.title).to eq("")
+    end
   end
   context "#vernacular_title" do
     it "shows vernacular title without edition when there isn't one" do


### PR DESCRIPTION
Callnumber browse items that don't have a corresponding record in catalog solr were causing the site to break. This situation can happen when an item has been deleted in Alma, but the callnumber browse index is out of date. 

The temporary solution is to print nothing for the title in the list. 

![image](https://github.com/mlibrary/catalog-browse/assets/4235919/24a64016-d0b0-4c91-84c9-e1d33eba33d3)
