### PR TITLE
[LIBSEARCH-919] Add a class to Author browse links for GA tracking

### DIFF
--- a/views/authors.erb
+++ b/views/authors.erb
@@ -35,7 +35,7 @@
                       <dt>See:</dt>
                     <% end %>
                     <dd>
-                      <a href="<%= cr.url%>"><%=cr.author_display%></a> (<%=cr.record_text%>)
+                      <a href="<%= cr.url%>" class="cross-reference-link"><%=cr.author_display%></a> (<%=cr.record_text%>)
                       <% if cr.heading_link? %>
                         <%= erb :'components/external_link', locals: { url: cr.heading_link, text: 'About this author', classes: 'vernacular pipe' } %>
                       <% end %>


### PR DESCRIPTION
# Overview
There is currently no direct way for GTM to track cross reference links while browsing by author. The `cross-reference-link` class has been added.

This pull request resolves [LIBSEARCH-919](https://mlit.atlassian.net/browse/LIBSEARCH-919).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Run [the site](http://localhost:4567/author?query=Twain%2C+Mark%2C+1835-1910) and see if the class shows in the source code.