### PR TITLE
solr cloud for authors is optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "puma"
 gem "faraday"
 gem "yabeda-puma-plugin"
 gem "yabeda-prometheus"
+gem "canister"
 
 group :development do
   gem "sinatra-contrib"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
     ast (2.4.2)
     base64 (0.1.1)
     byebug (11.1.3)
+    canister (0.9.2)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
@@ -145,6 +146,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  canister
   climate_control
   faraday
   listen

--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -4,6 +4,7 @@ require "byebug" if development?
 
 require "yaml"
 
+require_relative "lib/services"
 require_relative "lib/catalog_solr_client"
 require_relative "lib/utilities/browse_solr_client"
 require_relative "lib/utilities/string_cleaner"

--- a/env.example
+++ b/env.example
@@ -1,4 +1,8 @@
 BIBLIO_SOLR='http://biblio-server/solr'
+AUTHOR_SOLR='http://catalog-solr-server/solr'
 BROWSE_SOLR='http://catalog-solr-server/solr'
 CALLNUMBER_CORE='callnumbers'
 AUTHORITY_CORE='authors'
+SOLR_USER='solr'
+SOLR_PASSWORD='SolrRocks'
+SOLR_CLOUD_ON='false'

--- a/lib/models/author_list.rb
+++ b/lib/models/author_list.rb
@@ -6,7 +6,7 @@ class AuthorList < BrowseListPresenter
       num_rows_to_display: num_rows_to_display,
       original_reference: original_reference,
       banner_reference: banner_reference,
-      browse_solr_client: BrowseSolrClient.new(core: ENV.fetch("AUTHORITY_CORE"), match_field: "term", q: "browse_field:name")
+      browse_solr_client: BrowseSolrClient.new(solr_url: S.author_solr, core: S.authority_core, match_field: "term", q: "browse_field:name", solr_cloud_on: S.solr_cloud_on?)
     )
 
     new(browse_list: browse_list)

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,19 @@
+require "canister"
+
+Services = Canister.new
+S = Services
+
+S.register(:solr_cloud_on?) do
+  ENV["SOLR_CLOUD_ON"] == "true"
+end
+
+S.register(:author_solr) do
+  ENV["AUTHOR_SOLR"] || ENV["BROWSE_SOLR"]
+end
+
+[
+  "BROWSE_SOLR", "BIBLIO_SOLR", "SOLR_USER", "SOLR_PASSWORD",
+  "CALLNUMBER_CORE", "AUTHORITY_CORE"
+].each do |e|
+  Services.register(e.downcase.to_sym) { ENV[e] }
+end

--- a/lib/utilities/browse_solr_client.rb
+++ b/lib/utilities/browse_solr_client.rb
@@ -1,11 +1,12 @@
 require "faraday"
 
 class BrowseSolrClient
-  def initialize(solr_url: ENV.fetch("BROWSE_SOLR"), core: ENV.fetch("CALLNUMBER_CORE"), match_field: "callnumber", q: "*:*")
+  def initialize(solr_url: ENV.fetch("BROWSE_SOLR"), core: ENV.fetch("CALLNUMBER_CORE"), match_field: "callnumber", q: "*:*", solr_cloud_on: false)
     @conn = Faraday.new(
       url: solr_url
     ) do |f|
       f.request :json
+      f.request :authorization, :basic, ENV["SOLR_USER"], ENV["SOLR_PASSWORD"] if solr_cloud_on
       #  f.request :retry, {max: 1, retry_statuses: [500]}
       f.response :json
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,11 @@ module RSpecMixin
   include Rack::Test::Methods
   def app = Sinatra::Application
 end
+
+# set up dependencies
+S.register(:author_solr) { S.browse_solr }
+S.register(:solr_cloud_on?) { false }
+
 RSpec.configure do |config|
   config.include RSpecMixin
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
# Overview

This PR enables the optional use of solr cloud for author browse. If the environment variable `SOLR_CLOUD_ON` is true then  `BrowseSolrClient` will try to use basic auth when connecting to solr. 

To make this change easier, Canister has been added to handle environment variables.

For tests `S.solr_cloud_on?` is set to false and the assumption is all browse solr urls are the same. 

