### PR TITLE
Deploy Browse as a full service (UI)

### DIFF
--- a/config/search_dropdown.yml
+++ b/config/search_dropdown.yml
@@ -32,7 +32,7 @@
   - :label: ISBN/ISSN/OCLC/etc
     :value: isn
     :tip: Search by ISSN (8-digit code), ISBN (13 or 10-digit code), or OCLC number (e.g., 0040-781X; 0747581088; 921446069).
-- :label: Browse by [BETA]
+- :label: Browse by
   :tip: Browse Tip
   :options:
   - :label: Browse by call number (LC and Dewey)

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -78,14 +78,6 @@
     <%= erb :'layout/search_box', locals: { list: list } %>
     <%= erb :'layout/datastore_navigation' %>
     <main class="viewport-container">
-      <%
-        url_params = request.params.map {|key, value| key} 
-        if !url_params.include? 'direction'
-      %>
-        <m-callout dismissable icon>
-          <p><span class="strong">Browse by <%= list.name %> beta:</span> We're testing a new feature to browse the catalog by <%= list.name %>. Let us know what you think at our <%= erb :'components/external_link', locals: { url: list.feedback_url, text: 'feedback form' } %>.</p>
-        </m-callout>
-      <% end %>
       <h1 id="maincontent" tabindex="-1">
         <%= list.title %>
       </h1>


### PR DESCRIPTION
# Overview
Catalog Browse is officially out of beta! This pull request removes everything beta related.

- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Load up [the site](http://localhost:4567/callnumber?query=UM1) and check the dropdown. Has `[BETA]` been removed?
  - Has the `m-callout` component been removed containing the feedback survey.
