### PR TITLE
First page bug

### DIFF
--- a/lib/models/author_list.rb
+++ b/lib/models/author_list.rb
@@ -6,6 +6,7 @@ class AuthorList < BrowseListPresenter
       num_rows_to_display: num_rows_to_display,
       original_reference: original_reference,
       banner_reference: banner_reference,
+      match_field: "term",
       browse_solr_client: BrowseSolrClient.new(core: S.authority_collection, match_field: "term", q: "browse_field:name")
     )
 

--- a/lib/models/browse_list.rb
+++ b/lib/models/browse_list.rb
@@ -1,9 +1,15 @@
 class BrowseList
   attr_reader :original_reference, :num_rows_to_display, :num_matches, :exact_matches, :banner_reference, :index_docs
 
-  def self.for(direction:, reference_id:, num_rows_to_display:, original_reference:,
+  def self.for(
+    direction:,
+    reference_id:,
+    num_rows_to_display:,
+    original_reference:,
     banner_reference:,
-    browse_solr_client: BrowseSolrClient.new)
+    browse_solr_client: BrowseSolrClient.new,
+    match_field: "PlACEHOLDER"
+  )
 
     my_banner_reference = banner_reference
     exact_matches = browse_solr_client.exact_matches(value: original_reference)
@@ -32,8 +38,8 @@ class BrowseList
     else
       # index_before:, index_after:
       return BrowseList::Empty.new if reference_id.nil? || reference_id == ""
-      index_before = browse_solr_client.browse_reference_on_bottom(reference_id: reference_id, rows: 3)
-      index_after = browse_solr_client.browse_reference_on_top(reference_id: reference_id, rows: num_rows_to_display - 1)
+      index_before = browse_solr_client.browse_reference_on_bottom(reference_id: reference_id, rows: 3, field: match_field)
+      index_after = browse_solr_client.browse_reference_on_top(reference_id: reference_id, rows: num_rows_to_display - 1, field: match_field)
       my_banner_reference = index_after&.body&.dig("response", "docs")&.first&.dig("id")
       # need above and below
       BrowseList::ReferenceInMiddle.new(

--- a/lib/models/call_number_list.rb
+++ b/lib/models/call_number_list.rb
@@ -5,7 +5,8 @@ class CallNumberList < BrowseListPresenter
       reference_id: reference_id,
       num_rows_to_display: num_rows_to_display,
       original_reference: original_reference,
-      banner_reference: banner_reference
+      banner_reference: banner_reference,
+      match_field: "callnumber"
     )
 
     bib_ids = browse_list.docs.map { |x| x["bib_id"] }

--- a/lib/models/subject_list.rb
+++ b/lib/models/subject_list.rb
@@ -6,6 +6,7 @@ class SubjectList < BrowseListPresenter
       num_rows_to_display: num_rows_to_display,
       original_reference: original_reference,
       banner_reference: banner_reference,
+      match_field: "term",
       browse_solr_client: BrowseSolrClient.new(core: S.authority_collection, match_field: "term", q: "browse_field:subject")
     )
 

--- a/lib/utilities/browse_solr_client.rb
+++ b/lib/utilities/browse_solr_client.rb
@@ -15,17 +15,17 @@ class BrowseSolrClient
     @q = q
   end
 
-  def browse_reference_on_top(reference_id:, rows: 20)
+  def browse_reference_on_top(reference_id:, rows: 20, field: "id")
     # square brackets includes reference in return
-    range = "id:[\"#{reference_id}\" TO *]"
-    sort = "id asc"
+    range = "#{field}:[\"#{reference_id}\" TO *]"
+    sort = "#{field} asc"
     browse(rows: rows, sort: sort, range: range)
   end
 
-  def browse_reference_on_bottom(reference_id:, rows: 20)
+  def browse_reference_on_bottom(reference_id:, rows: 20, field: "id")
     # curly brackets exclues reference in return
-    range = "id:{* TO \"#{reference_id}\"}"
-    sort = "id desc"
+    range = "#{field}:{* TO \"#{reference_id}\"}"
+    sort = "#{field} desc"
     browse(rows: rows, sort: sort, range: range)
   end
 

--- a/spec/models/browse_list_spec.rb
+++ b/spec/models/browse_list_spec.rb
@@ -9,7 +9,8 @@ describe BrowseList do
         num_rows_to_display: 20,
         original_reference: nil,
         banner_reference: nil,
-        browse_solr_client: @browse_client
+        browse_solr_client: @browse_client,
+        match_field: "my_match_field"
       }
     end
     subject do
@@ -19,11 +20,17 @@ describe BrowseList do
       @params[:direction] = "next"
       allow(@browse_client).to receive(:browse_reference_on_top)
       expect(subject.class).to eq(BrowseList::ReferenceOnTop)
+      expect(@browse_client).to have_received(:browse_reference_on_top).with(
+        {reference_id: nil, rows: 22}
+      )
     end
     it "returns a ReferenceOnTop when direction is previous" do
       @params[:direction] = "previous"
       allow(@browse_client).to receive(:browse_reference_on_bottom)
       expect(subject.class).to eq(BrowseList::ReferenceOnBottom)
+      expect(@browse_client).to have_received(:browse_reference_on_bottom).with(
+        {reference_id: nil, rows: 21}
+      )
     end
     context "direction is nil" do
       it "returns a ReferenceInMiddle if there's a reference_id" do
@@ -31,6 +38,8 @@ describe BrowseList do
         allow(@browse_client).to receive(:browse_reference_on_top)
         allow(@browse_client).to receive(:browse_reference_on_bottom)
         expect(subject.class).to eq(BrowseList::ReferenceInMiddle)
+        expect(@browse_client).to have_received(:browse_reference_on_top).with({field: "my_match_field", reference_id: "Something", rows: 19})
+        expect(@browse_client).to have_received(:browse_reference_on_bottom).with({field: "my_match_field", reference_id: "Something", rows: 3})
       end
       it "returns a Empty if there in not a reference_id" do
         expect(subject.class).to eq(BrowseList::Empty)

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -14,15 +14,15 @@ describe "requests" do
   context "get /callnumber" do
     it "for a successful query, returns status OK" do
       stub_solr_get_request(url: "#{@call_number_collection}/select", query: hash_including({fq: 'callnumber:"Thing"'}), output: fixture("biblio_results.json"))
-      stub_solr_get_request(url: "#{@call_number_collection}/select", query: hash_including({sort: "id desc"}), output: fixture("callnumbers_before.json"))
-      stub_solr_get_request(url: "#{@call_number_collection}/select", query: hash_including({fq: 'id:["Thing" TO *]'}), output: fixture("callnumbers_results.json"))
+      stub_solr_get_request(url: "#{@call_number_collection}/select", query: hash_including({sort: "callnumber desc"}), output: fixture("callnumbers_before.json"))
+      stub_solr_get_request(url: "#{@call_number_collection}/select", query: hash_including({fq: 'callnumber:["Thing" TO *]'}), output: fixture("callnumbers_results.json"))
       stub_biblio_get_request(url: "biblio/select", query: hash_including({}), output: fixture("biblio_results_middle.json"))
       get "/callnumber", {query: "Thing"}
       expect(last_response.status).to eq(200)
     end
     it "for a network error, it still returns a successful response, but with an error message" do
       stub_solr_get_request(url: "#{@call_number_collection}/select", query: hash_including({fq: 'callnumber:"Thing"'}), no_return: true).to_timeout
-      stub_solr_get_request(url: "#{@call_number_collection}/select", query: hash_including({sort: "id desc"}), no_return: true).to_timeout
+      stub_solr_get_request(url: "#{@call_number_collection}/select", query: hash_including({sort: "callnumber desc"}), no_return: true).to_timeout
       get "/callnumber", {query: "Thing"}
       expect(last_response.status).to eq(200)
     end
@@ -30,14 +30,14 @@ describe "requests" do
   context "get /author" do
     it "returns status OK" do
       stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({fq: 'term:"Thing"'}), output: fixture("author_exact_matches.json"))
-      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({sort: "id desc"}), output: fixture("author_results.json"))
-      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({fq: 'id:["Thing" TO *]'}), output: fixture("author_results.json"))
+      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({sort: "term desc"}), output: fixture("author_results.json"))
+      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({fq: 'term:["Thing" TO *]'}), output: fixture("author_results.json"))
       get "/author", {query: "Thing"}
       expect(last_response.status).to eq(200)
     end
     it "for a network error, it still returns a successful response, but with an error message" do
       stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({fq: 'term:"Thing"'}), no_return: true).to_timeout
-      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({sort: "id desc"}), no_return: true).to_timeout
+      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({sort: "term desc"}), no_return: true).to_timeout
       get "/author", {query: "Thing"}
       expect(last_response.status).to eq(200)
     end
@@ -45,14 +45,14 @@ describe "requests" do
   context "get /subject" do
     it "returns status OK" do
       stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({fq: 'term:"Thing"'}), output: fixture("author_exact_matches.json"))
-      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({sort: "id desc"}), output: fixture("subject_results.json"))
-      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({fq: 'id:["Thing" TO *]'}), output: fixture("subject_results.json"))
+      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({sort: "term desc"}), output: fixture("subject_results.json"))
+      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({fq: 'term:["Thing" TO *]'}), output: fixture("subject_results.json"))
       get "/subject", {query: "Thing"}
       expect(last_response.status).to eq(200)
     end
     it "for a network error, it still returns a successful response, but with an error message" do
       stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({fq: 'term:"Thing"'}), no_return: true).to_timeout
-      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({sort: "id desc"}), no_return: true).to_timeout
+      stub_solr_get_request(url: "#{@authority_collection}/select", query: hash_including({sort: "term desc"}), no_return: true).to_timeout
       get "/subject", {query: "Thing"}
       expect(last_response.status).to eq(200)
     end

--- a/spec/utilities/browse_solr_client_spec.rb
+++ b/spec/utilities/browse_solr_client_spec.rb
@@ -2,6 +2,50 @@ describe BrowseSolrClient do
   subject do
     described_class.new
   end
+  context "#browse_reference_on_top" do
+    it "uses id as the default range and sort field" do
+      s = stub_solr_get_request(url: "#{S.call_number_collection}/select", query: hash_including(
+        {
+          fq: 'id:["whatever" TO *]',
+          sort: "id asc"
+        }
+      ))
+      subject.browse_reference_on_top(reference_id: "whatever")
+      expect(s).to have_been_requested
+    end
+    it "uses field value as the default range and sort field when given" do
+      s = stub_solr_get_request(url: "#{S.call_number_collection}/select", query: hash_including(
+        {
+          fq: 'some_other_field:["whatever" TO *]',
+          sort: "some_other_field asc"
+        }
+      ))
+      subject.browse_reference_on_top(reference_id: "whatever", field: "some_other_field")
+      expect(s).to have_been_requested
+    end
+  end
+  context "#browse_reference_on_bottom" do
+    it "uses id as the default range and sort field" do
+      s = stub_solr_get_request(url: "#{S.call_number_collection}/select", query: hash_including(
+        {
+          fq: 'id:{* TO "whatever"}',
+          sort: "id desc"
+        }
+      ))
+      subject.browse_reference_on_bottom(reference_id: "whatever")
+      expect(s).to have_been_requested
+    end
+    it "uses field value as the default range and sort field when given" do
+      s = stub_solr_get_request(url: "#{S.call_number_collection}/select", query: hash_including(
+        {
+          fq: 'some_other_field:{* TO "whatever"}',
+          sort: "some_other_field desc"
+        }
+      ))
+      subject.browse_reference_on_bottom(reference_id: "whatever", field: "some_other_field")
+      expect(s).to have_been_requested
+    end
+  end
   context "#exact_matches" do
     it "returns an array of ids for an exact match" do
       stub_solr_get_request(url: "#{S.call_number_collection}/select", query: hash_including({fq: 'callnumber:"Thing"'}), output: fixture("biblio_results.json"))


### PR DESCRIPTION
There's been a problem with callnumber browse where the first page of results only has 2 results preceding the searched for result. This PR fixes that bug.

The problem has been that for the first page of results we need to use a different field for the filter query and the sort than we do have next and previous results. For next and previous we can use the `id` field because it has the full id, so the id will be found in the list. For the first page we only have what string the user submitted, so we need to use either the `callnumber` or the `term` field.


-------------------------------
This doesn't work with `author` or `subject` browse. Need to do more investigating.