### PR TITLE
Replaces Rack::Logger for Sinatra's logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "yabeda-puma-plugin"
 gem "yabeda-prometheus"
 gem "canister"
 gem "rackup"
+gem "semantic_logger"
 
 group :development do
   gem "sinatra-contrib"

--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,9 @@ gem "yabeda-prometheus"
 gem "canister"
 gem "rackup"
 gem "semantic_logger"
+gem "sinatra-contrib"
 
 group :development do
-  gem "sinatra-contrib"
   gem "listen"
   gem "standard"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     ruby-next-core (1.0.3)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    semantic_logger (4.15.0)
+      concurrent-ruby (~> 1.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -170,6 +172,7 @@ DEPENDENCIES
   rack-test
   rackup
   rspec
+  semantic_logger
   simplecov
   sinatra
   sinatra-contrib

--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -1,5 +1,6 @@
 require "sinatra"
 require "sinatra/reloader" if development?
+require "sinatra/custom_logger"
 require "byebug" if development?
 
 require "yaml"
@@ -19,6 +20,8 @@ require_relative "lib/models/subject_list"
 require_relative "lib/models/subject_item"
 require_relative "lib/models/search_dropdown"
 require_relative "lib/models/datastores"
+
+set :logger, S.logger
 
 CatalogSolrClient.configure do |config|
   config.solr_url = S.biblio_solr

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require "canister"
+require "semantic_logger"
 
 Services = Canister.new
 S = Services
@@ -23,4 +24,22 @@ end
   "BIBLIO_SOLR", "SOLR_USER", "SOLR_PASSWORD", "BASE_URL", "SEARCH_URL"
 ].each do |e|
   Services.register(e.downcase.to_sym) { ENV[e] }
+end
+
+S.register(:log_stream) do
+  $stdout.sync = true
+  $stdout
+end
+
+S.register(:logger) do
+  SemanticLogger["catalog-browse"]
+end
+
+case ENV["APP_ENV"]
+when "production"
+  SemanticLogger.add_appender(io: S.log_stream, level: :info, formatter: :json)
+when "test" # explicitly don't wnat an appender when running tests
+  nil
+else
+  SemanticLogger.add_appender(io: S.log_stream, level: :info, formatter: :color)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ require "simplecov"
 require "climate_control"
 SimpleCov.start
 ENV["RACK_ENV"] = "test"
+ENV["APP_ENV"] = "test"
 require File.expand_path "../../catalog-browse.rb", __FILE__
 module RSpecMixin
   include Rack::Test::Methods


### PR DESCRIPTION
There was a deprecation warning for `Rack::Logger`. This PR replaces `Rack::Logger` with Semantic Logger. 