### PR TITLE
change design-system to pull latest version

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -7,11 +7,11 @@
     <link rel="shortcut icon" href="<%=S.base_url%>/favicon.ico">
     <link rel="icon" href="<%=S.base_url%>/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="<%=S.base_url%>/favicon-180x180.png">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/umich-lib.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/umich-lib.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@48,600,0,0..200">
     <link rel="stylesheet" href="<%=S.base_url%>/browse.css">
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/dist/umich-lib/umich-lib.esm.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/dist/umich-lib/umich-lib.esm.js"></script>
     <!-- Google Tag Manager -->
     <script>
       (function (w, d, s, l, i) {


### PR DESCRIPTION
# Overview
m-chat has had an updated skin in the old Design System repository. To make sure the CDN is always up to date, the version has been updated to latest. The CDN will be replaced when the new Design System is ready for launch.


