### PR TITLE
Adding `set` to resolve: `web_1  | W, [2024-07-31T15:53:28.302636 #1]  WARN -- : attack prevented by Rack::Protection::JsonCsrf`

### DIFF
--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -23,6 +23,7 @@ require_relative "lib/models/search_dropdown"
 require_relative "lib/models/datastores"
 
 set :logger, S.logger
+set :protection, except: [:json_csrf]
 
 CatalogSolrClient.configure do |config|
   config.solr_url = S.biblio_solr


### PR DESCRIPTION
# Overview
Code provided by @bertrama:

```
diff --git a/catalog-browse.rb b/catalog-browse.rb
index 3e68331..47c11c9 100644
--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -23,6 +23,7 @@ require_relative "lib/models/search_dropdown"
 require_relative "lib/models/datastores"
 
 set :logger, S.logger
+set :protection, except: [:json_csrf]
 
 CatalogSolrClient.configure do |config|
   config.solr_url = S.biblio_solr
```
