### PR TITLE
This disables RackProtection::JsonCsrf which was causing problems in …

### DIFF
--- a/catalog-browse.rb
+++ b/catalog-browse.rb
@@ -23,6 +23,7 @@ require_relative "lib/models/search_dropdown"
 require_relative "lib/models/datastores"
 
 set :logger, S.logger
+set :protection, except: [:json_csrf]
 
 CatalogSolrClient.configure do |config|
   config.solr_url = S.biblio_solr


### PR DESCRIPTION
…production.

# Overview

RackProtection::JsonCsrf will respond with a 403 status when a request is made, with the Referer header set, but no Origin header.

Javascript's fetch function was making requests with the Referer header set, but no Origin header, when the request was being made to the same site.  Cross site requests set an Origin header, so this was not visible when evaluating a staging deployment.

Disabling RackProtection::JsonCsrf is likely not harmful because catalog browse does not do credentialed requests.   

## Anything else?
Consider re-enabling if requests are made with credentials.

## Testing

Start up a development instance and run:
```
curl 'http://localhost:4567/carousel?query=GV1541%20.M28%201996' \
-H 'User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0' \
-H 'Accept: */*' \
-H 'Accept-Language: en-US,en;q=0.5' \
-H 'Accept-Encoding: gzip, deflate, br, zstd' \
-H 'Referer: https://search.lib.umich.edu/catalog/record/11103032259' \
-H 'Connection: keep-alive'
```