### PR TITLE
[LIBSEARCH-1032] Test an integration of book covers from Syndetic Solutions in the shelf carousel

### DIFF
--- a/lib/models/carousel_list.rb
+++ b/lib/models/carousel_list.rb
@@ -34,6 +34,18 @@ class CarouselList
       @browse_doc["callnumber"]&.strip
     end
 
+    def isbn
+      @catalog_doc["isbn"]&.first&.strip
+    end
+
+    def issn
+      @catalog_doc["issn"]&.first&.strip
+    end
+
+    def oclc
+      @catalog_doc["oclc"]&.first&.strip
+    end
+
     def mms_id
       @browse_doc["bib_id"]
     end
@@ -52,6 +64,9 @@ class CarouselList
         author: author,
         date: date,
         call_number: call_number,
+        isbn: isbn,
+        issn: issn,
+        oclc: oclc,
         url: url
       }
     end

--- a/spec/models/carousel_list_spec.rb
+++ b/spec/models/carousel_list_spec.rb
@@ -20,6 +20,8 @@ end
 describe CarouselList::CarouselItem do
   before(:each) do
     @catalog_doc = JSON.parse(fixture("biblio_results.json"))["response"]["docs"].first
+    @catalog_doc["isbn"] = ["1-5011-8342-7"]
+    @catalog_doc["issn"] = ["1096-9942"]
     @browse_doc = JSON.parse(fixture("callnumbers_results.json"))["response"]["docs"].first
   end
   subject do
@@ -35,10 +37,10 @@ describe CarouselList::CarouselItem do
     expect(subject.call_number).to eq("Z 253 .U6 1963")
   end
   it "has an isbn" do
-    expect(subject.isbn).to eq(nil)
+    expect(subject.isbn).to eq("1-5011-8342-7")
   end
   it "has an issn" do
-    expect(subject.issn).to eq(nil)
+    expect(subject.issn).to eq("1096-9942")
   end
   it "has an oclc" do
     expect(subject.oclc).to eq("2497305")
@@ -58,8 +60,8 @@ describe CarouselList::CarouselItem do
         author: "United States. Government Printing Office",
         call_number: "Z 253 .U6 1963",
         date: "1950",
-        isbn: nil,
-        issn: nil,
+        isbn: "1-5011-8342-7",
+        issn: "1096-9942",
         oclc: "2497305",
         title: "Theory and practice of composition.",
         url: "#{S.search_url}/catalog/record/990011613060106381"

--- a/spec/models/carousel_list_spec.rb
+++ b/spec/models/carousel_list_spec.rb
@@ -34,6 +34,15 @@ describe CarouselList::CarouselItem do
   it "has a call_number" do
     expect(subject.call_number).to eq("Z 253 .U6 1963")
   end
+  it "has an isbn" do
+    expect(subject.isbn).to eq(nil)
+  end
+  it "has an issn" do
+    expect(subject.issn).to eq(nil)
+  end
+  it "has an oclc" do
+    expect(subject.oclc).to eq("2497305")
+  end
   it "has an mms_id" do
     expect(subject.mms_id).to eq("990011613060106381")
   end
@@ -49,6 +58,9 @@ describe CarouselList::CarouselItem do
         author: "United States. Government Printing Office",
         call_number: "Z 253 .U6 1963",
         date: "1950",
+        isbn: nil,
+        issn: nil,
+        oclc: "2497305",
         title: "Theory and practice of composition.",
         url: "#{S.search_url}/catalog/record/990011613060106381"
 


### PR DESCRIPTION
# Overview
Search has access to Syndetic Solutions book cover API until November 28. In order to pull the images, we need access to the record's `isbn`, `issn`, and/or `oclc` data. This pull request adds those fields to the carousel API.

This pull request fixes [LIBSEARCH-1032](https://mlit.atlassian.net/browse/LIBSEARCH-1032).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
  - Break the new/updated unit tests to make sure they're working properly.
