### PR TITLE
Book Cover property for Shelf Browse

### DIFF
--- a/lib/models/carousel_list.rb
+++ b/lib/models/carousel_list.rb
@@ -58,12 +58,12 @@ class CarouselList
       "https://search.lib.umich.edu/catalog/record/#{mms_id}"
     end
 
-    def book_cover  
+    def book_cover
       query_params = [:isbn, :issn, :oclc].map do |parameter|
         value = send(parameter)
         "#{parameter}=#{value}" unless value.nil? || value.empty?
       end
-      "https://www.syndetics.com/index.php?client=umichaa&pagename=lc.jpg&#{query_params.compact.join('&')}"
+      "https://www.syndetics.com/index.php?client=umichaa&pagename=lc.jpg&#{query_params.compact.join("&")}"
     end
 
     def to_h

--- a/lib/models/carousel_list.rb
+++ b/lib/models/carousel_list.rb
@@ -58,6 +58,14 @@ class CarouselList
       "https://search.lib.umich.edu/catalog/record/#{mms_id}"
     end
 
+    def book_cover  
+      query_params = [:isbn, :issn, :oclc].map do |parameter|
+        value = send(parameter)
+        "#{parameter}=#{value}" unless value.nil? || value.empty?
+      end
+      "https://www.syndetics.com/index.php?client=umichaa&pagename=lc.jpg&#{query_params.compact.join('&')}"
+    end
+
     def to_h
       {
         title: title,
@@ -67,7 +75,8 @@ class CarouselList
         isbn: isbn,
         issn: issn,
         oclc: oclc,
-        url: url
+        url: url,
+        book_cover: book_cover
       }
     end
   end

--- a/spec/models/carousel_list_spec.rb
+++ b/spec/models/carousel_list_spec.rb
@@ -68,7 +68,7 @@ describe CarouselList::CarouselItem do
         oclc: "2497305",
         title: "Theory and practice of composition.",
         url: "#{S.search_url}/catalog/record/990011613060106381",
-        book_cover: "https://www.syndetics.com/index.php?client=umichaa&pagename=lc.jpg&isbn=1-5011-8342-7&issn=1096-9942&oclc=2497305",
+        book_cover: "https://www.syndetics.com/index.php?client=umichaa&pagename=lc.jpg&isbn=1-5011-8342-7&issn=1096-9942&oclc=2497305"
       }
     )
   end

--- a/spec/models/carousel_list_spec.rb
+++ b/spec/models/carousel_list_spec.rb
@@ -54,6 +54,9 @@ describe CarouselList::CarouselItem do
   it "has a url" do
     expect(subject.url).to eq("#{S.search_url}/catalog/record/990011613060106381")
   end
+  it "has a book_cover" do
+    expect(subject.book_cover).to eq("https://www.syndetics.com/index.php?client=umichaa&pagename=lc.jpg&isbn=1-5011-8342-7&issn=1096-9942&oclc=2497305")
+  end
   it "has a hash output" do
     expect(subject.to_h).to eq(
       {
@@ -64,8 +67,8 @@ describe CarouselList::CarouselItem do
         issn: "1096-9942",
         oclc: "2497305",
         title: "Theory and practice of composition.",
-        url: "#{S.search_url}/catalog/record/990011613060106381"
-
+        url: "#{S.search_url}/catalog/record/990011613060106381",
+        book_cover: "https://www.syndetics.com/index.php?client=umichaa&pagename=lc.jpg&isbn=1-5011-8342-7&issn=1096-9942&oclc=2497305",
       }
     )
   end


### PR DESCRIPTION
# Overview
Shelf Browse uses the `isbn`, `issn`, and `oclc` values to help generate the query parameters for grabbing the book cover image from Syndetics. This pull request creates a `book_cover` method that combines that methods to generate the URL.

## Anything else?
When this is up and running, it will be applied to Search. When Search is deployed, then the `isbn`, `issn`, and `oclc` properties can be removed. Since this is only adding a hash and not deleting or modifying existing properties, it should have no effect to current Search when launched.

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
  - Break the new/updated unit tests to make sure they're working properly.
